### PR TITLE
Small Quality of Life issue

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -283,7 +283,7 @@ func getCommandExample(command string, args ...string) string {
 		}
 		cmd = fmt.Sprintf("%s %s %s", exc, command, strings.Join(args, " "))
 	}
-	return "`" + strings.TrimRight(cmd, " ") + "`"
+	return "`" + strings.TrimSpace(cmd) + "`"
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -269,12 +270,20 @@ func getExecutable() string {
 
 func getCommandExample(command string, args ...string) string {
 	ex := getExecutable()
+	var cmd string
 	if strings.Contains(ex, "go-build") {
 		// If we are running in a go build environment, we need to tell the user how to start the server
-		return fmt.Sprintf("`go run . %s %s`", command, strings.Join(args, " "))
+		cmd = fmt.Sprintf("go run . %s %s", command, strings.Join(args, " "))
 	} else {
-		return fmt.Sprintf("`%s %s %s`", ex, command, strings.Join(args, " "))
+		// if in the current directory, we should add a period for *nix systems otherwise show the full path
+		cwd, _ := os.Getwd()
+		exc := ex
+		if strings.HasPrefix(ex, cwd) && runtime.GOOS != "windows" {
+			exc = "./" + strings.TrimPrefix(ex, cwd+"/")
+		}
+		cmd = fmt.Sprintf("%s %s %s", exc, command, strings.Join(args, " "))
 	}
+	return "`" + strings.TrimRight(cmd, " ") + "`"
 }
 
 func init() {


### PR DESCRIPTION
Instead of showing full path to binary on *nix systems when you're running the binary for the CWD, just show ./eds instead.

Trim the extra space when no arguments passed in