### PR TITLE
[VCARB-215] Support Building Smaller Binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The target driver is configured using the `--url` option. The driver that is sel
 - **s3** - used to stream data into a S3 compatible cloud storage (AWS, Google Cloud, Minio, etc)
 - **kafka** - used to stream data into a Kafka topic
 - **eventhub** - used to stream data to Microsoft Azure [EventHub](https://azure.microsoft.com/en-us/products/event-hubs)
+- **file** - used to stream data into a folder on the local machine. This is useful for bulk export or testing locally.
 
 You can get a list of drivers with example URL patterns by running the following:
 
@@ -138,7 +139,7 @@ The server will automatically detect crashes, report them to Shopmonkey and rest
 
 ## Auto Update
 
-Coming soon.
+The server can be automatically updated from Shopmonkey HQ. This remote update capability is disabled when running inside Docker.
 
 # Deployment
 
@@ -168,6 +169,19 @@ You should use the arguments without the name of the binary such as:
 
 > [!IMPORTANT]
 > You should enroll the server outside of Docker initially and mount the generated `config.toml` file after setup into your container at runtime. This file should be treated as a secret and should not be committed to your Docker image.
+
+## Building a smaller binary
+
+You can build a binary with only the driver that is required by using the following build tags:
+
+- `use_custom_driver` - required
+- `use_[driver]` - such as `use_mysql`
+
+You build with the following go command:
+
+```
+go build -tags use_custom_driver,use_mysql
+```
 
 # Security
 

--- a/cmd/driver_eventhub.go
+++ b/cmd/driver_eventhub.go
@@ -1,0 +1,6 @@
+//go:build use_eventhub || !use_custom_driver
+// +build use_eventhub !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/eventhub"

--- a/cmd/driver_file.go
+++ b/cmd/driver_file.go
@@ -1,0 +1,6 @@
+//go:build use_file || !use_custom_driver
+// +build use_file !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/file"

--- a/cmd/driver_kafka.go
+++ b/cmd/driver_kafka.go
@@ -1,0 +1,6 @@
+//go:build use_kafka || !use_custom_driver
+// +build use_kafka !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/kafka"

--- a/cmd/driver_mysql.go
+++ b/cmd/driver_mysql.go
@@ -1,0 +1,6 @@
+//go:build use_mysql || !use_custom_driver
+// +build use_mysql !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/mysql"

--- a/cmd/driver_postgres.go
+++ b/cmd/driver_postgres.go
@@ -1,0 +1,6 @@
+//go:build use_postgres || use_postgresql || !use_custom_driver
+// +build use_postgres use_postgresql !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/postgresql"

--- a/cmd/driver_s3.go
+++ b/cmd/driver_s3.go
@@ -1,0 +1,6 @@
+//go:build use_s3 || !use_custom_driver
+// +build use_s3 !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/s3"

--- a/cmd/driver_snowflake.go
+++ b/cmd/driver_snowflake.go
@@ -1,0 +1,6 @@
+//go:build use_snowflak || !use_custom_driver
+// +build use_snowflak !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/snowflake"

--- a/cmd/driver_sqlserver.go
+++ b/cmd/driver_sqlserver.go
@@ -1,0 +1,6 @@
+//go:build use_sqlserver || !use_custom_driver
+// +build use_sqlserver !use_custom_driver
+
+package cmd
+
+import _ "github.com/shopmonkeyus/eds/internal/drivers/sqlserver"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,16 +19,6 @@ import (
 	"github.com/shopmonkeyus/go-common/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	// Register all drivers
-	_ "github.com/shopmonkeyus/eds/internal/drivers/eventhub"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/file"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/kafka"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/mysql"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/postgresql"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/s3"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/snowflake"
-	_ "github.com/shopmonkeyus/eds/internal/drivers/sqlserver"
 )
 
 var dataDir string

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1047,7 +1047,7 @@ var serverHelpCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		yellow := color.New(color.FgYellow, color.Bold).SprintFunc()
 		cyan := color.New(color.FgCyan).SprintFunc()
-		black := color.New(color.FgBlack).SprintFunc()
+		black := color.New(color.FgBlack, color.Bold).SprintFunc()
 		whiteBold := color.New(color.FgWhite, color.Bold).SprintFunc()
 		white := color.New(color.FgWhite).SprintFunc()
 		green := color.New(color.FgGreen).SprintFunc()
@@ -1060,13 +1060,19 @@ var serverHelpCmd = &cobra.Command{
 		if len(args) == 0 {
 			fmt.Println("This server version supports the following integrations:")
 			fmt.Println()
+			if len(driverMetadata) == 0 {
+				fmt.Println("No integrations found.")
+				fmt.Println()
+				os.Exit(1)
+			}
 			for _, metadata := range driverMetadata {
-				fmt.Printf("%-25s%s\n", yellow(metadata.Name), whiteBold(metadata.Description))
-				fmt.Printf("%14s%s: %s\n", "", black("Example url"), cyan(metadata.ExampleURL))
+				fmt.Printf("%s\n", yellow(metadata.Name))
+				fmt.Printf("%s\n", whiteBold(metadata.Description))
+				fmt.Printf("%s: %s\n", black("Example url"), cyan(metadata.ExampleURL))
 				fmt.Println()
 			}
 			fmt.Println()
-			fmt.Println("Example usage:")
+			fmt.Println(whiteBold("Example usage:"))
 			fmt.Println()
 			c := filepath.Base(os.Args[0])
 			if Version == "dev" {


### PR DESCRIPTION
Adds support for building a binary that only has one driver. By default, will build all.

Updated README with instructions.