### PR TITLE
[VCARB-260] Regression: only override the api-url in enroll if explicitly overriden in command line

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -502,7 +502,7 @@ var serverCmd = &cobra.Command{
 					os.Exit(1)
 				}
 				args := []string{"enroll", code, "--silent"}
-				if apiurl != "" {
+				if cmd.Flags().Changed("api-url") {
 					args = append(args, "--api-url", apiurl)
 				}
 				cmd := exec.Command(getExecutable(), args...)


### PR DESCRIPTION
@robindiddams made a change just before release to pass in --api-url to enroll when overridden but the codepath will set a default if not explicitly passed in which will force stable url by default instead of using the enrollment code prefix.

This change will only pass it down if explicitly set in commandline