### PR TITLE
[VCARB-277] S3: when using schema validation path, make sure to include the S3 path prefix

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,6 @@ github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFt
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
-github.com/shopmonkeyus/go-common v0.0.70 h1:ZuhGf7EKZ6hYmazcQUEfV4FB+bjmV3HWu2diEHwHENA=
-github.com/shopmonkeyus/go-common v0.0.70/go.mod h1:YOSV3UmAG1D8T7rb1+sK2ktIVtJQ35FAFzn2+MqhToM=
 github.com/shopmonkeyus/go-common v0.0.71 h1:CXdr+JUrS1C+KvcabtleoPNt6ho6yDzSBpBgvCKSLhw=
 github.com/shopmonkeyus/go-common v0.0.71/go.mod h1:9m7rHfgCDg+v9qMXF648l24nRMpCyUYEf6fxFNnBtYg=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/internal/drivers/s3/s3.go
+++ b/internal/drivers/s3/s3.go
@@ -357,9 +357,9 @@ func (p *s3Driver) MaxBatchSize() int {
 func (p *s3Driver) process(_ context.Context, logger logger.Logger, event internal.DBChangeEvent, dryRun bool) (bool, error) {
 	var key string
 	if event.SchemaValidatedPath != nil {
-		key = *event.SchemaValidatedPath
+		key = path.Join(p.prefix, *event.SchemaValidatedPath)
 	} else {
-		key = fmt.Sprintf("%s%s/%s.json", p.prefix, event.Table, event.GetPrimaryKey())
+		key = path.Join(p.prefix, event.Table, event.GetPrimaryKey()+".json")
 	}
 	if dryRun {
 		logger.Trace("would store %s:%s", p.bucket, key)


### PR DESCRIPTION
When using schema validation, make sure we include the S3 path prefix in the calculated output filename.

@athomas-byrider this will fix your issue.