### PR TITLE
[VCARB-306] add ability to replay data from a specific time offset

### DIFF
--- a/internal/importer.go
+++ b/internal/importer.go
@@ -47,6 +47,9 @@ type ImporterConfig struct {
 
 	// Only create the schema but do not import any data.
 	SchemaOnly bool
+
+	// NoDelete is true if the importer should not delete the tables before importing.
+	NoDelete bool
 }
 
 // Importer is the interface that must be implemented by all importer implementations

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -31,8 +31,10 @@ func Run(logger logger.Logger, config internal.ImporterConfig, handler Handler) 
 	if err != nil {
 		return fmt.Errorf("unable to get schema: %w", err)
 	}
-	if err := handler.CreateDatasource(schema); err != nil {
-		return err
+	if !config.NoDelete {
+		if err := handler.CreateDatasource(schema); err != nil {
+			return err
+		}
 	}
 	if config.SchemaOnly {
 		return nil


### PR DESCRIPTION
Adds ability to replay data from a time offset

```
go run . import --api-key $TOKEN --url $URL -v --timeOffset '2024-05-01T00:00:00Z' --no-delete
```

2 new flags to import:

- `timeOffset` optional date time in RFC3339 format
- `no-delete` optional flag to tell importer not to drop and recreate tables

