### PR TITLE
[LOTUS-5324] potentially breaking change: Adds timestamp to s3 driver record file names

### DIFF
--- a/internal/drivers/s3/s3.go
+++ b/internal/drivers/s3/s3.go
@@ -352,7 +352,7 @@ func (p *s3Driver) process(_ context.Context, logger logger.Logger, event intern
 	if event.SchemaValidatedPath != nil {
 		key = path.Join(p.prefix, *event.SchemaValidatedPath)
 	} else {
-		key = path.Join(p.prefix, event.Table, event.GetPrimaryKey()+".json")
+		key = path.Join(p.prefix, event.Table, fmt.Sprintf("%d-%s.json", time.UnixMilli(event.Timestamp).Unix(), event.GetPrimaryKey()))
 	}
 	if dryRun {
 		logger.Trace("would store %s:%s", p.bucket, key)

--- a/internal/drivers/s3/s3_test.go
+++ b/internal/drivers/s3/s3_test.go
@@ -171,13 +171,14 @@ func TestEventPathWithPrefix(t *testing.T) {
 	s3.prefix = prefix
 	s3.ch = make(chan job, 1)
 	ok, err := s3.Process(logger, internal.DBChangeEvent{
-		Table: "table",
-		Key:   []string{"pk"},
+		Table:     "table",
+		Key:       []string{"pk"},
+		Timestamp: 500000000,
 	})
 	assert.False(t, ok)
 	assert.NoError(t, err)
 	job := <-s3.ch
-	assert.Equal(t, "withprefix/table/pk.json", job.key)
+	assert.Equal(t, "withprefix/table/500000-pk.json", job.key)
 }
 
 func TestEventPathNoPrefix(t *testing.T) {
@@ -185,11 +186,12 @@ func TestEventPathNoPrefix(t *testing.T) {
 	var s3 s3Driver
 	s3.ch = make(chan job, 1)
 	ok, err := s3.Process(logger, internal.DBChangeEvent{
-		Table: "table",
-		Key:   []string{"pk"},
+		Table:     "table",
+		Key:       []string{"pk"},
+		Timestamp: 2000,
 	})
 	assert.False(t, ok)
 	assert.NoError(t, err)
 	job := <-s3.ch
-	assert.Equal(t, "table/pk.json", job.key)
+	assert.Equal(t, "table/2-pk.json", job.key)
 }

--- a/internal/e2e/driver_s3.go
+++ b/internal/e2e/driver_s3.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
@@ -35,7 +36,7 @@ func (d *driverS3Test) Validate(logger logger.Logger, dir string, url string, ev
 	}
 	res, err := client.GetObject(context.Background(), &awss3.GetObjectInput{
 		Bucket: aws.String(dbname),
-		Key:    aws.String(fmt.Sprintf("%s/%s.json", event.Table, event.GetPrimaryKey())),
+		Key:    aws.String(fmt.Sprintf("%s/%d-%s.json", event.Table, time.UnixMilli(event.Timestamp).Unix(), event.GetPrimaryKey())),
 	})
 	if err != nil {
 		return fmt.Errorf("error getting object: %w", err)


### PR DESCRIPTION
This may break workflows for companies making use of our S3 Driver. Before merging and releasing the new version, any companies using the S3 driver should be informed of these changes!