### PR TITLE
[Lotus-5621] Fix EDS Batching Bug

### DIFF
--- a/internal/drivers/snowflake/snowflake.go
+++ b/internal/drivers/snowflake/snowflake.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -185,9 +186,10 @@ func (p *snowflakeDriver) Flush(logger logger.Logger) error {
 			case "UPDATE":
 				// slight optimization to skip records that just have an updatedDate and nothing else
 				justUpdatedDate := len(record.Diff) == 1 && record.Diff[0] == "updatedDate"
+				justUpdatedMeta := len(record.Diff) == 2 && slices.Contains(record.Diff, "updatedDate") && slices.Contains(record.Diff, "meta")
 				noUpdates := len(record.Diff) == 0
-				if justUpdatedDate || noUpdates {
-					logger.Trace("skipping update because only updatedDate changed for %s/%s", record.Table, record.Id)
+				if justUpdatedDate || noUpdates || justUpdatedMeta {
+					logger.Trace("skipping update because only either updatedDate, meta and updatedDate, or nothing changed for %s/%s", record.Table, record.Id)
 					continue
 				}
 			case "DELETE":

--- a/internal/util/batcher.go
+++ b/internal/util/batcher.go
@@ -42,45 +42,71 @@ func (b *Batcher) Add(table string, id string, operation string, diff []string, 
 		}
 	}
 	hashkey := table + primaryKey
-	index, found := b.pks[hashkey]
+	index, previousEventFound := b.pks[hashkey]
 
 	appendRecord := func() {
 		b.records = append(b.records, &Record{Table: table, Id: primaryKey, Operation: operation, Diff: diff, Object: payload, Event: event})
 		b.pks[hashkey] = uint(len(b.records) - 1)
 	}
 
-	if operation == "DELETE" {
-		if found {
-			// if found, remove the old record (could be insert or update)
-			b.records = append(b.records[:index], b.records[index+1:]...)
-			delete(b.pks, hashkey)
-		}
+	appendDeleteRecord := func() {
 		b.records = append(b.records, &Record{Table: table, Id: primaryKey, Operation: operation, Event: event})
 		b.pks[hashkey] = uint(len(b.records) - 1)
-	} else {
-		if found {
-			entry := b.records[index]
-			if entry.Operation == "INSERT" {
-				// don't combine if previous entry was an insert
-				appendRecord()
-			} else {
-				//For UPDATE operations, merge the diff keys
-				for _, key := range diff {
-					if !SliceContains(entry.Diff, key) {
-						entry.Diff = append(entry.Diff, key)
-					}
-				}
-				if len(entry.Diff) == 0 {
-					entry.Diff = diff
-				}
-				entry.Event = event
-				entry.Operation = operation
-				maps.Copy(entry.Object, payload) // upsert the payload with the new update
-			}
+	}
+
+	type batchCondition int
+	const (
+		withoutBatch batchCondition = iota
+		updateWithBatch
+		deleteWithBatch
+		deleteWithoutBatch
+	)
+
+	var previousRecord *Record
+	if previousEventFound {
+		previousRecord = b.records[index]
+	}
+
+	batchType := withoutBatch
+	switch operation {
+	case "DELETE":
+		if previousEventFound {
+			batchType = deleteWithBatch
 		} else {
-			// not found just add it
-			appendRecord()
+			batchType = deleteWithoutBatch
 		}
+	case "UPDATE":
+		if previousEventFound {
+			switch previousRecord.Operation {
+			case "INSERT":
+				batchType = withoutBatch
+			case "UPDATE":
+				batchType = updateWithBatch
+			}
+		}
+	}
+
+	switch batchType {
+	case withoutBatch:
+		appendRecord()
+	case updateWithBatch:
+		for _, key := range diff {
+			if !SliceContains(previousRecord.Diff, key) {
+				previousRecord.Diff = append(previousRecord.Diff, key)
+			}
+		}
+		if len(previousRecord.Diff) == 0 {
+			previousRecord.Diff = diff
+		}
+		previousRecord.Event = event
+		previousRecord.Operation = operation
+		maps.Copy(previousRecord.Object, payload) // upsert the payload with the new update
+	case deleteWithBatch:
+		b.records = append(b.records[:index], b.records[index+1:]...)
+		delete(b.pks, hashkey)
+		appendDeleteRecord()
+	case deleteWithoutBatch:
+		appendDeleteRecord()
 	}
 }
 

--- a/internal/util/batcher_test.go
+++ b/internal/util/batcher_test.go
@@ -49,22 +49,3 @@ func TestBatcherAddCombineUpdate(t *testing.T) {
 	assert.Equal(t, 34, records[1].Object["age"])
 	assert.Equal(t, []string{"name", "age"}, records[1].Diff)
 }
-
-func TestBatcherAddHandlePK(t *testing.T) {
-	b := NewBatcher()
-	// TODO: Resolve ambiguity around the id input to the Add function and then revise the expected values for this test.
-	// Some of these tests might be more appropriate for the DBChangeEvent GetPrimaryKey function.
-	// The above mentioned ambiguity is problematic because the drivers use Record.Id for inserts, but the Add function combines records on dbchange.Key, dbchange.After,payload.id, or the id argument to Add
-	b.Add("user", "0", "UPDATE", []string{}, map[string]interface{}{"id": "A"}, &internal.DBChangeEvent{Key: []string{"b", "c"}, After: json.RawMessage(`{"id":"a"}`)})
-	assert.Equal(t, "A", b.Records()[0].Object["id"])
-	assert.Equal(t, "c", b.Records()[0].Id)
-	b.Add("user", "0", "UPDATE", []string{}, map[string]interface{}{}, &internal.DBChangeEvent{Key: []string{"d", "e"}, After: json.RawMessage(`{"id":"f"}`)})
-	assert.Equal(t, nil, b.Records()[1].Object["id"])
-	assert.Equal(t, "e", b.Records()[1].Id)
-	b.Add("user", "0", "UPDATE", []string{}, map[string]interface{}{"id": "A"}, nil)
-	assert.Equal(t, "A", b.Records()[2].Object["id"])
-	assert.Equal(t, "A", b.Records()[2].Id)
-	b.Add("user", "0", "UPDATE", []string{}, map[string]interface{}{}, nil)
-	assert.Equal(t, nil, b.Records()[3].Object["id"])
-	assert.Equal(t, "0", b.Records()[3].Id)
-}


### PR DESCRIPTION
The EDS batching functionality that combines multiple dbchanges on the same record into one statement had a logic error that caused some insert statements to be dropped if they were followed very closely by an update.

This can be fixed by adding a condition to the batching logic that doesn't batch for insert statements.

I also propose to refactor the Batcher.Add function to improve readability, as in its current form it has complicated branching logic that is error prone. If we decide the refactor is too much I have the original with the fix applied in one of the branch commits that we can revert to.

There was also a test for Batcher.Add that did not properly catch the bug. I have modified that test so that it was failing properly and now passes with the fix applied. I also added a test to confirm that updates are not batched with inserts, and one that tests the batching of update events.

Also by popular demand I added an optimization to ignore events that only update meta and updated date.

Here is a loom with an in-depth look at what was happening if anyone is curious or wants more details:
https://www.loom.com/share/4110f78ccf2e4d539558439b6a97c045

I tested by creating a customer and stepping through the offending function and ensuring that it behaves properly. I also have Snowflake connected and confirmed that the record was being inserted into the Snowflake database. I then created some vehicles, inventory labors, fleets, and appointments and verified that the records were inserted into the Snowflake database.
