### PR TITLE
[LOTUS-5613] EDS Snowflake Driver Update Whole Record If Newer

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Show Kafka output
         run: docker logs eds-init-kafka-1
       - name: Run tests
+        env:
+          SM_SNOWFLAKE_PASSWORD: ${{ secrets.SM_SNOWFLAKE_PASSWORD }}
         run: make e2e
       - name: Stop containers
         run: docker compose down

--- a/cmd/fork.go
+++ b/cmd/fork.go
@@ -71,6 +71,7 @@ var forkCmd = &cobra.Command{
 
 		natsurl := mustFlagString(cmd, "server", true)
 		url := mustFlagString(cmd, "url", true)
+		updateStrategy, _ := cmd.Flags().GetString("update-strategy")
 		creds := mustFlagString(cmd, "creds", !util.IsLocalhost(natsurl))
 		consumerSuffix := mustFlagString(cmd, "consumer-suffix", false)
 		maxAckPending := mustFlagInt(cmd, "maxAckPending", false)
@@ -115,7 +116,7 @@ var forkCmd = &cobra.Command{
 		}
 
 		// note: don't use ctx here because we want the driver to continue running during shutdown so we can control the flush
-		driver, err := internal.NewDriver(context.Background(), logger, url, schemaRegistry, tracker, datadir)
+		driver, err := internal.NewDriver(context.Background(), logger, url, schemaRegistry, tracker, datadir, updateStrategy)
 		if err != nil {
 			logger.Error("error creating driver: %s", err)
 			os.Exit(exitCodeIncorrectUsage)
@@ -291,6 +292,7 @@ func init() {
 	forkCmd.Flags().String("logs-dir", "", "the directory for storing logs")
 	forkCmd.Flags().String("creds", "", "the server credentials file provided by Shopmonkey")
 	forkCmd.Flags().String("url", "", "driver connection string")
+	forkCmd.Flags().String("update-strategy", "", "the update strategy to use")
 	forkCmd.Flags().String("api-url", "", "url to shopmonkey api")
 	forkCmd.Flags().Int("maxAckPending", defaultMaxAckPending, "the number of max ack pending messages")
 	forkCmd.Flags().Int("maxPendingBuffer", defaultMaxPendingBuffer, "the maximum number of messages to pull from nats to buffer")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -479,6 +479,7 @@ var serverCmd = &cobra.Command{
 		}
 		dataDir := getDataDir(cmd, logger)
 		driverURL := viper.GetString("url")
+		updateStrategy := viper.GetString("update_strategy")
 		server := mustFlagString(cmd, "server", false)
 		apikey := viper.GetString("token")
 		if apikey == "" {
@@ -488,6 +489,7 @@ var serverCmd = &cobra.Command{
 		verbose := mustFlagBool(cmd, "verbose", false)
 		noRestart := mustFlagBool(cmd, "no-restart", false)
 
+		// TODO: figure out why failing the empty import to Snowflake results in the fork remaining alive
 		// run the wrapper to handle the rest of the code from inside the wrapper
 		wrapper := mustFlagBool(cmd, "wrapper", false)
 		if !wrapper {
@@ -836,6 +838,7 @@ var serverCmd = &cobra.Command{
 			var maskedURL *string
 			if success && validated {
 				viper.Set("url", config.URL)
+				viper.Set("update_strategy", config.UpdateStrategy)
 				if err := viper.WriteConfig(); err != nil {
 					logger.Error("failed to write config: %s", err)
 				}
@@ -995,6 +998,7 @@ var serverCmd = &cobra.Command{
 				"--logs-dir", sessionLogsDir,
 				"--url", driverURL,
 				"--server", natsurl,
+				"--update-strategy", updateStrategy,
 			)
 			result, err := command.Fork(command.ForkArgs{
 				Log:              logger,

--- a/internal/driver.go
+++ b/internal/driver.go
@@ -35,7 +35,7 @@ type DriverConfig struct {
 	// DataDir is the directory where the driver can store data.
 	DataDir string
 
-	// UpdateStrategy is the strategy to use for updating data. Blank or "standard" are default; "after" updates the whole record in case an out-of-order event is recieved
+	// UpdateStrategy is the strategy to use for updating data. Empty string or "standard" are default; "after" updates the whole record in case an out-of-order event is recieved
 	UpdateStrategy string
 }
 

--- a/internal/driver.go
+++ b/internal/driver.go
@@ -34,6 +34,9 @@ type DriverConfig struct {
 
 	// DataDir is the directory where the driver can store data.
 	DataDir string
+
+	// UpdateStrategy is the strategy to use for updating data. Blank or "standard" are default; "after" updates the whole record in case an out-of-order event is recieved
+	UpdateStrategy string
 }
 
 // DriverSessionHandler is for drivers that want to receive the session id
@@ -229,7 +232,7 @@ func RegisterDriver(protocol string, driver Driver) {
 }
 
 // NewDriver creates a new driver for the given URL.
-func NewDriver(ctx context.Context, logger logger.Logger, urlString string, registry SchemaRegistry, tracker *tracker.Tracker, datadir string) (Driver, error) {
+func NewDriver(ctx context.Context, logger logger.Logger, urlString string, registry SchemaRegistry, tracker *tracker.Tracker, datadir string, updateStrategy string) (Driver, error) {
 	u, err := url.Parse(urlString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
@@ -254,6 +257,7 @@ func NewDriver(ctx context.Context, logger logger.Logger, urlString string, regi
 			SchemaRegistry: registry,
 			Tracker:        tracker,
 			DataDir:        datadir,
+			UpdateStrategy: updateStrategy,
 		}); err != nil {
 			return nil, err
 		}

--- a/internal/drivers/snowflake/snowflake.go
+++ b/internal/drivers/snowflake/snowflake.go
@@ -31,9 +31,9 @@ type snowflakeDriver struct {
 	batcher        *util.Batcher
 	locker         sync.Mutex
 	sessionID      string
-	updateStrategy string
 	dbname         string
 	dbschema       internal.DatabaseSchema
+	updateStrategy string
 	profilingInfo  DriverProfilingInfo
 }
 

--- a/internal/drivers/snowflake/sql.go
+++ b/internal/drivers/snowflake/sql.go
@@ -141,13 +141,14 @@ func nullableValue(c internal.SchemaProperty, wrap bool) string {
 	}
 }
 
-func toSQL(record *util.Record, model *internal.Schema, exists bool) (string, int) {
+func toSQL(record *util.Record, model *internal.Schema, exists bool, updateStrategy string) (string, int) {
 	var sql strings.Builder
 	var count int
 	if exists || record.Operation == "DELETE" {
 		sql.WriteString(toDeleteSQL(record))
 		count++
 	}
+	// TODO: What's with this logic
 	if record.Operation != "DELETE" {
 		if record.Operation == "INSERT" {
 			var columns []string
@@ -184,29 +185,87 @@ func toSQL(record *util.Record, model *internal.Schema, exists bool) (string, in
 			sql.WriteString(";\n")
 		} else {
 			// update
-			var updateValues []string
-			for _, name := range record.Diff {
-				if !util.SliceContains(model.Columns(), name) {
-					continue
+			switch updateStrategy {
+			case "after":
+				// Apply the whole after field if the updated date is later than the existing updated date
+				// Use MERGE for upsert operations (insert if not exists, update if exists)
+				// TODO Switch this to use MSVCC timestamp? Possibly separate PR?
+				var updateValues []string
+				var insertColumns []string
+				var insertVals []string
+
+				for _, name := range model.Columns() {
+					insertColumns = append(insertColumns, util.QuoteIdentifier(name))
+					if val, ok := record.Object[name]; ok {
+						c := model.Properties[name]
+						var fn string
+						switch c.Type {
+						case "object":
+							fn = "PARSE_JSON"
+						case "array":
+							if c.Items != nil && (c.Items.Type == "object" || c.Items.Type == "string") {
+								fn = "PARSE_JSON"
+							} else {
+								fn = "TO_VARIANT"
+							}
+						}
+						v := quoteValue(val, fn)
+						updateValues = append(updateValues, fmt.Sprintf("%s=%s", util.QuoteIdentifier(name), v))
+						insertVals = append(insertVals, v)
+					} else {
+						// For missing values, use nullable defaults for insert
+						c := model.Properties[name]
+						v := nullableValue(c, true)
+						insertVals = append(insertVals, v)
+					}
 				}
-				if val, ok := record.Object[name]; ok {
-					v := quoteValue(val, "")
-					updateValues = append(updateValues, fmt.Sprintf("%s=%s", util.QuoteIdentifier(name), v))
+
+				after, _ := record.Event.GetObject() // ignore error because we assume after is present in an update event
+
+				sql.WriteString("MERGE INTO ")
+				sql.WriteString(util.QuoteIdentifier(record.Table))
+				sql.WriteString(" AS target USING (SELECT ")
+				sql.WriteString(quoteValue(record.Id, ""))
+				sql.WriteString(" AS id, ")
+				sql.WriteString(quoteValue(after["updatedDate"], ""))
+				sql.WriteString(" AS updatedDate) AS source ON target.id = source.id ")
+
+				// WHEN MATCHED clause - update if updatedDate is newer
+				sql.WriteString("WHEN MATCHED AND source.updatedDate > target.updatedDate THEN UPDATE SET ")
+				sql.WriteString(strings.Join(updateValues, ","))
+
+				// WHEN NOT MATCHED clause - insert new record
+				sql.WriteString(" WHEN NOT MATCHED THEN INSERT (")
+				sql.WriteString(strings.Join(insertColumns, ","))
+				sql.WriteString(") VALUES (")
+				sql.WriteString(strings.Join(insertVals, ","))
+				sql.WriteString(");\n")
+			default: // "standard"
+				// Standard is applying just the diffs in the order they are received
+				var updateValues []string
+				for _, name := range record.Diff {
+					if !util.SliceContains(model.Columns(), name) {
+						continue
+					}
+					if val, ok := record.Object[name]; ok {
+						v := quoteValue(val, "")
+						updateValues = append(updateValues, fmt.Sprintf("%s=%s", util.QuoteIdentifier(name), v))
+					}
+					// else shouldn't be possible
 				}
-				// else shouldn't be possible
+				if len(updateValues) == 0 {
+					return sql.String(), count // in case we skipped, just return
+				}
+				sql.WriteString("UPDATE ")
+				sql.WriteString(util.QuoteIdentifier(record.Table))
+				sql.WriteString(" SET ")
+				sql.WriteString(strings.Join(updateValues, ","))
+				sql.WriteString(" WHERE ")
+				sql.WriteString(util.QuoteIdentifier("id"))
+				sql.WriteString("=")
+				sql.WriteString(quoteValue(record.Id, ""))
+				sql.WriteString(";\n")
 			}
-			if len(updateValues) == 0 {
-				return sql.String(), count // in case we skipped, just return
-			}
-			sql.WriteString("UPDATE ")
-			sql.WriteString(util.QuoteIdentifier(record.Table))
-			sql.WriteString(" SET ")
-			sql.WriteString(strings.Join(updateValues, ","))
-			sql.WriteString(" WHERE ")
-			sql.WriteString(util.QuoteIdentifier("id"))
-			sql.WriteString("=")
-			sql.WriteString(quoteValue(record.Id, ""))
-			sql.WriteString(";\n")
 		}
 		count++
 	}

--- a/internal/drivers/snowflake/sql_test.go
+++ b/internal/drivers/snowflake/sql_test.go
@@ -203,3 +203,73 @@ func TestToMergeSQL(t *testing.T) {
 	sql := toMergeSQL(record, model)
 	assert.Equal(t, condensed, sql)
 }
+
+func TestGenerateInsertFunction(t *testing.T) {
+	tests := []struct {
+		name     string
+		property internal.SchemaProperty
+		expected string
+	}{
+		{
+			name: "object type returns PARSE_JSON",
+			property: internal.SchemaProperty{
+				Type: "object",
+			},
+			expected: "PARSE_JSON",
+		},
+		{
+			name: "array with object items returns PARSE_JSON",
+			property: internal.SchemaProperty{
+				Type: "array",
+				Items: &internal.ItemsType{
+					Type: "object",
+				},
+			},
+			expected: "PARSE_JSON",
+		},
+		{
+			name: "array with string items returns PARSE_JSON",
+			property: internal.SchemaProperty{
+				Type: "array",
+				Items: &internal.ItemsType{
+					Type: "string",
+				},
+			},
+			expected: "PARSE_JSON",
+		},
+		{
+			name: "array with number items returns TO_VARIANT",
+			property: internal.SchemaProperty{
+				Type: "array",
+				Items: &internal.ItemsType{
+					Type: "number",
+				},
+			},
+			expected: "TO_VARIANT",
+		},
+		{
+			name: "array with null items returns TO_VARIANT",
+			property: internal.SchemaProperty{
+				Type: "array",
+				Items: &internal.ItemsType{
+					Type: "null",
+				},
+			},
+			expected: "TO_VARIANT",
+		},
+		{
+			name: "string type returns empty string",
+			property: internal.SchemaProperty{
+				Type: "string",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateInsertFunction(tt.property)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/drivers/snowflake/sql_test.go
+++ b/internal/drivers/snowflake/sql_test.go
@@ -27,12 +27,12 @@ func TestDBChanges(t *testing.T) {
 	batcher.Add(dbChange.Table, dbChange.ID, dbChange.Operation, dbChange.Diff, object, nil)
 	schema, err := registery.GetLatestSchema()
 	assert.NoError(t, err)
-	sql, count := toSQL(batcher.Records()[0], schema["order"], false)
+	sql, count := toSQL(batcher.Records()[0], schema["order"], false, "")
 	assert.Equal(t, 1, count)
 	assert.Equal(t, `UPDATE "order" SET "updatedDate"='2024-07-11T21:16:51.70856Z' WHERE "id"='zzdb46f9-b4d1-4d53-9a1e-f9a878ff03ae';
 `, sql)
 
-	sql, count = toSQL(batcher.Records()[0], schema["order"], true)
+	sql, count = toSQL(batcher.Records()[0], schema["order"], true, "")
 	assert.Equal(t, 2, count)
 	assert.Equal(t, `DELETE FROM "order" WHERE "id"='zzdb46f9-b4d1-4d53-9a1e-f9a878ff03ae';
 UPDATE "order" SET "updatedDate"='2024-07-11T21:16:51.70856Z' WHERE "id"='zzdb46f9-b4d1-4d53-9a1e-f9a878ff03ae';
@@ -45,7 +45,7 @@ UPDATE "order" SET "updatedDate"='2024-07-11T21:16:51.70856Z' WHERE "id"='zzdb46
 	object, err = dbChange.GetObject()
 	assert.NoError(t, err)
 	batcher.Add(dbChange.Table, dbChange.ID, dbChange.Operation, dbChange.Diff, object, nil)
-	sql, count = toSQL(batcher.Records()[0], schema["order"], false)
+	sql, count = toSQL(batcher.Records()[0], schema["order"], false, "")
 	assert.Equal(t, 1, count)
 	assert.Equal(t, "DELETE FROM \"order\" WHERE \"id\"='zzdb46f9-b4d1-4d53-9a1e-f9a878ff03ae';\n", sql)
 }

--- a/internal/e2e/driver_snowflake.go
+++ b/internal/e2e/driver_snowflake.go
@@ -55,7 +55,7 @@ func (d *driverSnowflakeTest) Validate(logger logger.Logger, dir string, url str
 	if err != nil {
 		return fmt.Errorf("error getting connection string: %w", err)
 	}
-	time.Sleep(2 * time.Second) // snowflake needs more time than others
+	time.Sleep(3 * time.Second) // snowflake needs more time than others
 	return validateSQLEvent(logger, event, "snowflake", connStr, d)
 }
 

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -82,7 +82,8 @@ type ConfigureRequest struct {
 	URL string `json:"url" msgpack:"url"`
 	// Backfill is a flag to indicate if the driver should backfill data.
 	// Configure does not perform a backfill, it is returned in the response so the next action can perform the backfill.
-	Backfill bool `json:"backfill" msgpack:"backfill"`
+	Backfill       bool   `json:"backfill" msgpack:"backfill"`
+	UpdateStrategy string `json:"updateStrategy" msgpack:"updateStrategy"`
 }
 
 type ConfigureResponse struct {
@@ -361,6 +362,9 @@ func (c *NotificationConsumer) callback(m *nats.Msg) {
 			req.URL = v
 		}
 		req.Backfill = getBool(notification.Data["backfill"])
+		if v, ok := notification.Data["updateStrategy"].(string); ok {
+			req.UpdateStrategy = v
+		}
 		c.configure(req, m)
 	case "import":
 		var req ImportRequest


### PR DESCRIPTION
The current implementation of the Snowflake driver can generate invalid data when changefeed events arrive out of order.

This PR does two things. It adds an option for a new update strategy that uses the entire `after` field in the dbchange event and only updates if the incoming record's timestamp is later than the `updatedDate` of the existing record. It also switches to use upsert (merge in snowflake) to avoid the problem of an insert event arriving out of order.

For the curious, `viper` handles reading the config file for the EDS server located in /data/config.toml. Additional work will need to be done to the front end to allow the update strategy to be configured in the SM EDS flow. For now it must be set in the config file.

Added a unit test for the new merge statement (snowflake's version of upsert). Also have the end to end test working for snowflake. Additionally, here is a video of me using a shop and seeing the data updated in Snowflake:
https://www.loom.com/share/da6faade3f884ff1a5b264080617b846