### PR TITLE
[LOTUS-5632] Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /shopmonkey.key.asc
 /data-*
 /quill-*.log
+/.vscode/
+eds-debug


### PR DESCRIPTION
the gitignore file doesn't exclude the .vscode artifacts directory or the eds-debug binary (which you need to attach to the fork process). This adds several dozen keystrokes to each commit which costs dearly in engineering time.
