### PR TITLE
[LOTUS-6387] Add end-to-end test for oudated model

### DIFF
--- a/internal/drivers/postgresql/sql.go
+++ b/internal/drivers/postgresql/sql.go
@@ -307,6 +307,9 @@ func addNewColumnsSQL(logger logger.Logger, columns []string, s *internal.Schema
 		sql.WriteString(quoteIdentifier(column))
 		sql.WriteString(" ")
 		sql.WriteString(propTypeToSQLType(prop))
+		if util.SliceContains(s.Required, column) && !prop.Nullable {
+			sql.WriteString(" NOT NULL")
+		}
 		sql.WriteString(";")
 		res = append(res, sql.String())
 	}

--- a/internal/drivers/snowflake/sql.go
+++ b/internal/drivers/snowflake/sql.go
@@ -385,6 +385,9 @@ func addNewColumnsSQL(logger logger.Logger, columns []string, s *internal.Schema
 		sql.WriteString(util.QuoteIdentifier(column))
 		sql.WriteString(" ")
 		sql.WriteString(propTypeToSQLType(prop))
+		if util.SliceContains(s.Required, column) && !prop.Nullable {
+			sql.WriteString(" NOT NULL")
+		}
 		sql.WriteString(";")
 		res = append(res, sql.String())
 	}

--- a/internal/e2e/api.go
+++ b/internal/e2e/api.go
@@ -16,7 +16,6 @@ import (
 	"github.com/shopmonkeyus/go-common/logger"
 )
 
-// schemaMap contains schema definitions for all model versions used in e2e tests
 var schemaMap = map[string]map[string]internal.Schema{
 	"order": {
 		"fff000111": {
@@ -43,10 +42,12 @@ var schemaMap = map[string]map[string]internal.Schema{
 					Type: "string",
 				},
 				"age": {
-					Type: "number",
+					Type:     "number",
+					Nullable: false,
 				},
 			},
 			PrimaryKeys: []string{"id"},
+			Required:    []string{"age"},
 		},
 		"fff000113-update": {
 			Table:        "order",
@@ -59,10 +60,12 @@ var schemaMap = map[string]map[string]internal.Schema{
 					Type: "string",
 				},
 				"age": {
-					Type: "number",
+					Type:     "number",
+					Nullable: false,
 				},
 			},
 			PrimaryKeys: []string{"id"},
+			Required:    []string{"age"},
 		},
 	},
 	"customer": {

--- a/internal/e2e/api.go
+++ b/internal/e2e/api.go
@@ -16,6 +16,98 @@ import (
 	"github.com/shopmonkeyus/go-common/logger"
 )
 
+// schemaMap contains schema definitions for all model versions used in e2e tests
+var schemaMap = map[string]map[string]internal.Schema{
+	"order": {
+		"fff000111": {
+			Table:        "order",
+			ModelVersion: "fff000111",
+			Properties: map[string]internal.SchemaProperty{
+				"id": {
+					Type: "string",
+				},
+				"name": {
+					Type: "string",
+				},
+			},
+			PrimaryKeys: []string{"id"},
+		},
+		"fff000112-update": {
+			Table:        "order",
+			ModelVersion: "fff000112-update",
+			Properties: map[string]internal.SchemaProperty{
+				"id": {
+					Type: "string",
+				},
+				"name": {
+					Type: "string",
+				},
+				"age": {
+					Type: "number",
+				},
+			},
+			PrimaryKeys: []string{"id"},
+		},
+		"fff000113-update": {
+			Table:        "order",
+			ModelVersion: "fff000113-update",
+			Properties: map[string]internal.SchemaProperty{
+				"id": {
+					Type: "string",
+				},
+				"name": {
+					Type: "string",
+				},
+				"age": {
+					Type: "number",
+				},
+			},
+			PrimaryKeys: []string{"id"},
+		},
+	},
+	"customer": {
+		"fff000111": {
+			Table:        "customer",
+			ModelVersion: "fff000111",
+			Properties: map[string]internal.SchemaProperty{
+				"id": {
+					Type: "string",
+				},
+				"name": {
+					Type: "string",
+				},
+			},
+			PrimaryKeys: []string{"id"},
+		},
+		"fff000112-update": {
+			Table:        "customer",
+			ModelVersion: "fff000112-update",
+			Properties: map[string]internal.SchemaProperty{
+				"id": {
+					Type: "string",
+				},
+				"name": {
+					Type: "string",
+				},
+			},
+			PrimaryKeys: []string{"id"},
+		},
+		"fff000113-update": {
+			Table:        "customer",
+			ModelVersion: "fff000113-update",
+			Properties: map[string]internal.SchemaProperty{
+				"id": {
+					Type: "string",
+				},
+				"name": {
+					Type: "string",
+				},
+			},
+			PrimaryKeys: []string{"id"},
+		},
+	},
+}
+
 type ShutdownFunc func()
 
 func setupServer(logger logger.Logger, creds string) (int, ShutdownFunc) {
@@ -64,43 +156,17 @@ func setupServer(logger logger.Logger, creds string) (int, ShutdownFunc) {
 	})
 
 	http.HandleFunc("/v3/schema/{object}/{version}", func(w http.ResponseWriter, r *http.Request) {
-		var resp internal.Schema
 		object := r.PathValue("object")
 		version := r.PathValue("version")
 		logger.Info("schema request received for %s %s", object, version)
-		switch object {
-		case "order":
-			resp = internal.Schema{
-				Table:        "order",
-				ModelVersion: version,
-				Properties: map[string]internal.SchemaProperty{
-					"id": {
-						Type: "string",
-					},
-					"name": {
-						Type: "string",
-					},
-					"age": {
-						Type: "number",
-					},
-				},
-				PrimaryKeys: []string{"id"},
-			}
-		case "customer":
-			resp = internal.Schema{
-				Table:        "customer",
-				ModelVersion: version,
-				Properties: map[string]internal.SchemaProperty{
-					"id": {
-						Type: "string",
-					},
-					"name": {
-						Type: "string",
-					},
-				},
-				PrimaryKeys: []string{"id"},
+
+		var resp internal.Schema
+		if objectSchemas, exists := schemaMap[object]; exists {
+			if schema, versionExists := objectSchemas[version]; versionExists {
+				resp = schema
 			}
 		}
+
 		logger.Info("schema fetched for %s %s", object, version)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)

--- a/internal/e2e/driver_postgres.go
+++ b/internal/e2e/driver_postgres.go
@@ -21,7 +21,7 @@ func (d *driverPostgresTest) Name() string {
 }
 
 func (d *driverPostgresTest) URL(dir string) string {
-	return fmt.Sprintf("postgres://%s:%s@127.0.0.1:15432/%s?sslmode=disable", dbuser, dbpass, dbname)
+	return fmt.Sprintf("postgres://%s:%s@127.0.0.1:15433/%s?sslmode=disable", dbuser, dbpass, dbname)
 }
 
 func (d *driverPostgresTest) QuoteTable(table string) string {

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -54,6 +54,10 @@ type e2eTestDisabled interface {
 	Disabled() bool
 }
 
+type tableName string
+
+var currentSchemaVersion = make(map[tableName]string)
+
 var tests = make([]e2eTest, 0)
 
 func registerTest(t e2eTest) {
@@ -131,6 +135,7 @@ func publishDBChangeEvent(logger logger.Logger, js jetstream.JetStream, table st
 
 func runDBChangeNewTableTest(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "customer", "INSERT", modelVersion, defaultPayload)
+	currentSchemaVersion["customer"] = modelVersion
 	if err != nil {
 		return err
 	}
@@ -140,6 +145,7 @@ func runDBChangeNewTableTest(logger logger.Logger, _ *nats.Conn, js jetstream.Je
 
 func runDBChangeNewTableTest2(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "customer", "INSERT", modelVersion2, defaultPayload)
+	currentSchemaVersion["customer"] = modelVersion2
 	if err != nil {
 		return err
 	}
@@ -149,6 +155,7 @@ func runDBChangeNewTableTest2(logger logger.Logger, _ *nats.Conn, js jetstream.J
 
 func runDBChangeNewColumnTest(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "order", "INSERT", modelVersion2, defaultPayload2)
+	currentSchemaVersion["order"] = modelVersion2
 	if err != nil {
 		return err
 	}
@@ -158,6 +165,7 @@ func runDBChangeNewColumnTest(logger logger.Logger, _ *nats.Conn, js jetstream.J
 
 func runDBChangeNewColumnTest2(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "order", "UPDATE", modelVersion3, defaultPayload2)
+	currentSchemaVersion["order"] = modelVersion3
 	if err != nil {
 		return err
 	}
@@ -176,6 +184,7 @@ func runDBChangeOldModelVersionTest(logger logger.Logger, _ *nats.Conn, js jetst
 
 func runDBChangeInsertTest(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "order", "INSERT", modelVersion, defaultPayload)
+	currentSchemaVersion["order"] = modelVersion
 	if err != nil {
 		return err
 	}
@@ -185,6 +194,7 @@ func runDBChangeInsertTest(logger logger.Logger, _ *nats.Conn, js jetstream.JetS
 
 func runDBChangeInsertTest2(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "customer", "INSERT", modelVersion2, defaultPayload)
+	currentSchemaVersion["customer"] = modelVersion2
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -39,6 +39,7 @@ const (
 	apikey            = "apikey"
 	defaultPayload    = `{"id":"12345","name":"test"}`
 	defaultPayload2   = `{"id":"12345","name":"test","age":1}`
+	oldModelPayload   = `{"id":"23456","name":"oldmodel"}`
 	defaultPayload3   = `{"id":"12345","name":"test","foo":1}`
 	eventDeliverDelay = time.Millisecond * 150
 )
@@ -98,7 +99,11 @@ func publishDBChangeEvent(logger logger.Logger, js jetstream.JetStream, table st
 	event.ID = util.Hash(time.Now())
 	event.Operation = operation
 	event.Table = table
-	event.Key = []string{"gcp-us-central1", "12345"}
+	var payloadMap map[string]any
+	if err := json.Unmarshal([]byte(payload), &payloadMap); err != nil {
+		return nil, fmt.Errorf("error unmarshalling payload: %w", err)
+	}
+	event.Key = []string{"gcp-us-central1", payloadMap["id"].(string)}
 	event.ModelVersion = modelVersion
 	event.Timestamp = time.Now().UnixMilli()
 	event.MVCCTimestamp = fmt.Sprintf("%d", time.Now().Nanosecond())
@@ -153,6 +158,15 @@ func runDBChangeNewColumnTest(logger logger.Logger, _ *nats.Conn, js jetstream.J
 
 func runDBChangeNewColumnTest2(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
 	event, err := publishDBChangeEvent(logger, js, "order", "UPDATE", modelVersion3, defaultPayload2)
+	if err != nil {
+		return err
+	}
+	time.Sleep(eventDeliverDelay)
+	return readResult(*event)
+}
+
+func runDBChangeOldModelVersionTest(logger logger.Logger, _ *nats.Conn, js jetstream.JetStream, readResult checkValidEvent) error {
+	event, err := publishDBChangeEvent(logger, js, "order", "INSERT", modelVersion, oldModelPayload)
 	if err != nil {
 		return err
 	}
@@ -347,6 +361,16 @@ func RunTests(logger logger.Logger, only []string) (bool, error) {
 				} else {
 					atomic.AddUint32(&pass, 1)
 					logger.Info("✅ dbchange new column (#2) test: %s succeeded in %s", name, time.Since(testStarted))
+				}
+				testStarted = time.Now()
+				if err := runDBChangeOldModelVersionTest(logger, nc, js, func(event internal.DBChangeEvent) error {
+					return test.Validate(_logger, tmpdir, url, event)
+				}); err != nil {
+					atomic.AddUint32(&fail, 1)
+					logger.Error("🔴 dbchange old model version test: %s failed: %s", name, err)
+				} else {
+					atomic.AddUint32(&pass, 1)
+					logger.Info("✅ dbchange old model version test: %s succeeded in %s", name, time.Since(testStarted))
 				}
 				testStarted = time.Now()
 				if err := runDBChangeInsertTest2(logger, nc, js, func(event internal.DBChangeEvent) error {


### PR DESCRIPTION
Messages with model versions that are old cause haywire in EDS. This bug is being fixed separately but the end-to-end tests didn't catch this case. This PR would expand the tests so they would have caught the problem. See the ticket for more details.
