### PR TITLE
[PIT-1164] Support rate limit on import

### DIFF
--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shopmonkeyus/go-common/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateExportJobReturnsErrorOn400(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"message": "invalid request"}`))
+	}))
+	defer srv.Close()
+
+	_, err := createExportJob(context.Background(), logger.NewTestLogger(), srv.URL, "test-api-key", exportJobCreateRequest{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid request")
+}
+
+func TestCreateExportJobReturnsJobIDOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"success": true, "data": {"jobId": "job-abc-123"}}`))
+	}))
+	defer srv.Close()
+
+	jobID, err := createExportJob(context.Background(), logger.NewTestLogger(), srv.URL, "test-api-key", exportJobCreateRequest{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "job-abc-123", jobID)
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -756,10 +756,13 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
-		runImport := func(ctx context.Context, url string, schemaOnly bool, validateOnly bool) (bool, bool, *string, *string) {
+		runImport := func(ctx context.Context, url string, schemaOnly bool, validateOnly bool, jobId string) (bool, bool, *string, *string) {
 			importargs := []string{"--url", url, "--api-key", apikey, "--no-confirm", "--data-dir", dataDir}
 			if schemaOnly {
 				importargs = append(importargs, "--schema-only")
+			}
+			if jobId != "" {
+				importargs = append(importargs, "--job-id", jobId)
 			}
 			if validateOnly {
 				importargs = append(importargs, "--validate-only", "--silent")
@@ -804,6 +807,7 @@ var serverCmd = &cobra.Command{
 					}
 					return false, false, &msg, nil // this means the url is invalid
 				default:
+					logger.Error("import failed with exit code %d: %s", ec, result.LastErrorLines)
 					var uploadLogPath string
 					uploadURL, err := getLogUploadURL(logger, apiurl, apikey, sessionId)
 					if err != nil {
@@ -833,7 +837,7 @@ var serverCmd = &cobra.Command{
 
 		configure := func(config *notification.ConfigureRequest) *notification.ConfigureResponse {
 			logger.Trace("received driver configuration. url: %s", cstr.Mask(config.URL))
-			success, validated, msg, uploadLogPath := runImport(ctx, config.URL, false, true)
+			success, validated, msg, uploadLogPath := runImport(ctx, config.URL, false, true, "")
 			var maskedURL *string
 			if success && validated {
 				viper.Set("url", config.URL)
@@ -863,10 +867,27 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
+		backFillInit := func(req *notification.InitBackfillRequest) *notification.InitBackfillResponse {
+			logger.Trace("received init backfill request")
+			if !req.Backfill {
+				return &notification.InitBackfillResponse{SessionID: sessionId, Success: true}
+			}
+			jobID, err := createExportJob(ctx, logger, apiurl, apikey, exportJobCreateRequest{})
+			if err != nil {
+				logger.Error("failed to create export job: %s", err)
+				errorMessage := err.Error()
+				return &notification.InitBackfillResponse{SessionID: sessionId, Success: false, Message: &errorMessage}
+			}
+			return &notification.InitBackfillResponse{SessionID: sessionId, Success: true, JobID: jobID}
+		}
+
 		importaction := func(req *notification.ImportRequest) *notification.ImportResponse {
 			logger.Trace("received import action")
 			pause() // pause the consumer, if any, from processing any data while we are importing
-			success, _, msg, uploadLogPath := runImport(ctx, driverURL, !req.Backfill, false)
+			success, _, msg, uploadLogPath := runImport(ctx, driverURL, !req.Backfill, false, req.JobID)
+			if !success {
+				return &notification.ImportResponse{SessionID: sessionId, Success: false, Message: msg, LogPath: uploadLogPath}
+			}
 			if !configured {
 				logger.Trace("driver configured")
 				configureChannel <- true
@@ -913,6 +934,7 @@ var serverCmd = &cobra.Command{
 			Upgrade:      upgrade,
 			SendLogs:     sendLogs,
 			Configure:    configure,
+			BackfillInit: backFillInit,
 			Import:       importaction,
 			DriverConfig: driverconfig,
 			Validate:     validate,

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -37,6 +37,9 @@ type NotificationHandler struct {
 	// Configure action is called to configure the server with a driver.
 	Configure func(config *ConfigureRequest) *ConfigureResponse
 
+	// BackfillInit is called to initialize backfill and create an export job.
+	BackfillInit func(*InitBackfillRequest) *InitBackfillResponse
+
 	// Import action is called to import data using the driver.
 	Import func(*ImportRequest) *ImportResponse
 
@@ -53,7 +56,19 @@ type SendLogsResponse struct {
 }
 
 type ImportRequest struct {
+	Backfill bool   `json:"backfill" msgpack:"backfill"`
+	JobID    string `json:"jobId" msgpack:"jobId"`
+}
+
+type InitBackfillRequest struct {
 	Backfill bool `json:"backfill" msgpack:"backfill"`
+}
+
+type InitBackfillResponse struct {
+	Success   bool    `json:"success" msgpack:"success"`
+	Message   *string `json:"message,omitempty" msgpack:"message,omitempty"`
+	SessionID string  `json:"sessionId" msgpack:"sessionId"`
+	JobID     string  `json:"jobId" msgpack:"jobId"`
 }
 
 type ImportResponse struct {
@@ -61,6 +76,7 @@ type ImportResponse struct {
 	Message   *string `json:"message,omitempty" msgpack:"message,omitempty"`
 	SessionID string  `json:"sessionId" msgpack:"sessionId"`
 	LogPath   *string `json:"-" msgpack:"-"`
+	JobID     string  `json:"jobId" msgpack:"jobId"`
 }
 
 type genericResponse struct {
@@ -248,7 +264,19 @@ func (c *NotificationConsumer) upgrade(version string) {
 	}
 }
 
-func (c *NotificationConsumer) importaction(req *ImportRequest) {
+func (c *NotificationConsumer) importaction(req *ImportRequest, m *nats.Msg) {
+	initResponse := c.handler.BackfillInit(&InitBackfillRequest{Backfill: req.Backfill})
+
+	if err := m.Respond([]byte(util.JSONStringify(initResponse))); err != nil {
+		c.logger.Error("failed to send import response: %s", err)
+		return
+	}
+	if !initResponse.Success {
+		return
+	}
+	req.JobID = initResponse.JobID
+	c.publishSimpleStatus("import", "")
+
 	c.wg.Add(1)
 	// NOTE: we're going to run this on a background goroutine so we can return the response immediately and allow
 	// other commands (like restart) to be processed while the import is running since the import could take a long time.
@@ -365,8 +393,7 @@ func (c *NotificationConsumer) callback(m *nats.Msg) {
 	case "import":
 		var req ImportRequest
 		req.Backfill = getBool(notification.Data["backfill"])
-		c.publishSimpleStatus("import", "")
-		c.importaction(&req)
+		c.importaction(&req, m)
 	case "driverconfig":
 		c.driverconfig(m)
 	case "validate":

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/shopmonkeyus/eds/internal"
 	"github.com/shopmonkeyus/eds/internal/util"
+	"github.com/shopmonkeyus/go-common/logger"
 	"github.com/stretchr/testify/assert"
 
 	_ "github.com/shopmonkeyus/eds/internal/drivers/eventhub" // this comment on this blank import is needed because Sonarqube doesn't understand Go modules
@@ -113,4 +114,72 @@ func TestAllDriversReturnFieldErrorsOnEmptyConfig(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestImportActionReturnsErrorOnInitFailure(t *testing.T) {
+	opts := natsserver.DefaultTestOptions
+	opts.Port = -1
+	srv := natsserver.RunServer(&opts)
+	defer srv.Shutdown()
+
+	nc, _ := nats.Connect(srv.ClientURL())
+	defer nc.Close()
+
+	errMsg := "init failed"
+	consumer := &NotificationConsumer{
+		nc:     nc,
+		logger: logger.NewTestLogger(),
+		handler: NotificationHandler{
+			BackfillInit: func(*InitBackfillRequest) *InitBackfillResponse {
+				return &InitBackfillResponse{Success: false, Message: &errMsg}
+			},
+		},
+	}
+
+	nc.Subscribe("test.import", func(msg *nats.Msg) {
+		consumer.importaction(&ImportRequest{Backfill: true}, msg)
+	})
+
+	reply, err := nc.Request("test.import", nil, time.Second)
+	assert.NoError(t, err)
+
+	var resp InitBackfillResponse
+	json.Unmarshal(reply.Data, &resp)
+	assert.False(t, resp.Success)
+	assert.Equal(t, "init failed", *resp.Message)
+}
+
+func TestImportActionReturnsSuccessOnInitSuccess(t *testing.T) {
+	opts := natsserver.DefaultTestOptions
+	opts.Port = -1
+	srv := natsserver.RunServer(&opts)
+	defer srv.Shutdown()
+
+	nc, _ := nats.Connect(srv.ClientURL())
+	defer nc.Close()
+
+	consumer := &NotificationConsumer{
+		nc:     nc,
+		logger: logger.NewTestLogger(),
+		handler: NotificationHandler{
+			BackfillInit: func(*InitBackfillRequest) *InitBackfillResponse {
+				return &InitBackfillResponse{Success: true, JobID: "job-123", SessionID: "session-456"}
+			},
+			Import: func(*ImportRequest) *ImportResponse {
+				return &ImportResponse{Success: true, SessionID: "session-456"}
+			},
+		},
+	}
+
+	nc.Subscribe("test.import", func(msg *nats.Msg) {
+		consumer.importaction(&ImportRequest{Backfill: true}, msg)
+	})
+
+	reply, err := nc.Request("test.import", nil, time.Second)
+	assert.NoError(t, err)
+
+	var resp InitBackfillResponse
+	json.Unmarshal(reply.Data, &resp)
+	assert.True(t, resp.Success)
+	assert.Equal(t, "job-123", resp.JobID)
 }


### PR DESCRIPTION
We are adding rate limits to the bulk export API route that EDS Import uses. This PR updates EDS to support returning the error to the user in the HQ EDS setup flow.

We accomplished this by adding a backfill initialization step that uses a request reply pattern. This allows the error message from the bulk export request to be shown on the EDS setup modal in HQ, similar to the way driver configuration errors are returned.
