### PR TITLE
[PIT-1245] EDS Show Empty Field Error to User

### DIFF
--- a/internal/driver.go
+++ b/internal/driver.go
@@ -369,21 +369,21 @@ func NewFieldError(field, message string) FieldError {
 	}
 }
 
-func GetRequiredStringValue(name string, values map[string]any) string {
+func GetRequiredStringValue(name string, values map[string]any) (string, *FieldError) {
 	if val, ok := values[name].(string); ok {
-		return val
+		return val, nil
 	}
-	panic("required field " + name + " not found") // should not happen
+	return "", &FieldError{Field: name, Message: string(fmt.Sprintf("required field %s not found", name))}
 }
 
-func GetRequiredIntValue(name string, values map[string]any) int {
+func GetRequiredIntValue(name string, values map[string]any) (int, *FieldError) {
 	if val, ok := values[name].(int); ok {
-		return val
+		return val, nil
 	}
 	if val, ok := values[name].(int64); ok {
-		return int(val)
+		return int(val), nil
 	}
-	panic("required field " + name + " not found") // should not happen
+	return 0, &FieldError{Field: name, Message: string(fmt.Sprintf("required field %s not found", name))}
 }
 
 func GetOptionalStringValue(name string, def string, values map[string]any) string {
@@ -409,13 +409,23 @@ func GetOptionalIntValue(name string, def int, values map[string]any) int {
 	return def
 }
 
-func URLFromDatabaseConfiguration(schema string, defport int, values map[string]any) string {
-	hostname := GetRequiredStringValue("Hostname", values)
+func URLFromDatabaseConfiguration(schema string, defport int, values map[string]any) (string, []FieldError) {
+	fieldErrors := []FieldError{}
+	hostname, err := GetRequiredStringValue("Hostname", values)
+	if err != nil {
+		fieldErrors = append(fieldErrors, *err)
+	}
 	username := GetOptionalStringValue("Username", "", values)
 	password := GetOptionalStringValue("Password", "", values)
 	port := GetOptionalIntValue("Port", defport, values)
+	database, err := GetRequiredStringValue("Database", values)
+	if err != nil {
+		fieldErrors = append(fieldErrors, *err)
+	}
+	if len(fieldErrors) > 0 {
+		return "", fieldErrors
+	}
 
-	database := GetRequiredStringValue("Database", values)
 	var u url.URL
 	u.Scheme = schema
 	if username != "" {
@@ -429,7 +439,7 @@ func URLFromDatabaseConfiguration(schema string, defport int, values map[string]
 	u.Path = database
 	urlString := u.String()
 	unescapedUrl, _ := url.QueryUnescape(urlString)
-	return unescapedUrl
+	return unescapedUrl, nil
 }
 
 func NewDatabaseConfiguration(defport int) []DriverField {

--- a/internal/drivers/eventhub/eventhub.go
+++ b/internal/drivers/eventhub/eventhub.go
@@ -277,7 +277,11 @@ func (p *eventHubDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *eventHubDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	val := internal.GetRequiredStringValue("Connection String", values)
+	fieldErrors := []internal.FieldError{}
+	val, fieldError := internal.GetRequiredStringValue("Connection String", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
 	// example:
 	// Endpoint=sb://shopmonkey-xx-test.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=x/x+x+x+x=;EntityPath=shopmonkey-eds-test
 	if !strings.HasPrefix(val, "Endpoint=") {
@@ -286,6 +290,9 @@ func (p *eventHubDriver) Validate(values map[string]any) (string, []internal.Fie
 	i := strings.Index(val, "://")
 	if i < 0 {
 		return "", []internal.FieldError{internal.NewFieldError("Connection String", "expected a url scheme after Endpoint= prefix")}
+	}
+	if len(fieldErrors) > 0 {
+		return "", fieldErrors
 	}
 	return "eventhub://" + val[i+3:], nil
 }

--- a/internal/drivers/eventhub/eventhub_test.go
+++ b/internal/drivers/eventhub/eventhub_test.go
@@ -7,17 +7,35 @@ import (
 )
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "valid connection string",
+			config:      map[string]any{"Connection String": "Endpoint=sb://shopmonkey-xx-test.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=x/x+x+x+x=;EntityPath=shopmonkey-eds-test"},
+			expectedURL: "eventhub://shopmonkey-xx-test.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=x/x+x+x+x=;EntityPath=shopmonkey-eds-test",
+		},
+		{
+			name:        "missing required field Connection String",
+			config:      map[string]any{"Format": "json"},
+			expectError: true,
+		},
+	}
+
 	var driver eventHubDriver
-
-	url, errs := driver.Validate(map[string]any{
-		"Connection String": "Endpoint=sb://shopmonkey-xx-test.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=x/x+x+x+x=;EntityPath=shopmonkey-eds-test",
-	})
-	assert.Empty(t, errs)
-	assert.Equal(t, "eventhub://shopmonkey-xx-test.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=x/x+x+x+x=;EntityPath=shopmonkey-eds-test", url)
-
-	url, errs = driver.Validate(map[string]any{
-		"Format": "json", // missing required field Connection String
-	})
-	assert.GreaterOrEqual(t, len(errs), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }

--- a/internal/drivers/eventhub/eventhub_test.go
+++ b/internal/drivers/eventhub/eventhub_test.go
@@ -14,4 +14,10 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, errs)
 	assert.Equal(t, "eventhub://shopmonkey-xx-test.servicebus.windows.net/;SharedAccessKeyName=send;SharedAccessKey=x/x+x+x+x=;EntityPath=shopmonkey-eds-test", url)
+
+	url, errs = driver.Validate(map[string]any{
+		"Format": "json", // missing required field Connection String
+	})
+	assert.GreaterOrEqual(t, len(errs), 1)
+	assert.Equal(t, "", url)
 }

--- a/internal/drivers/file/file.go
+++ b/internal/drivers/file/file.go
@@ -183,7 +183,11 @@ func (p *fileDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *fileDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	dir := internal.GetRequiredStringValue("Directory", values)
+	fieldErrors := []internal.FieldError{}
+	dir, fieldError := internal.GetRequiredStringValue("Directory", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
 	if dir == "/" {
 		return "", []internal.FieldError{internal.NewFieldError("Directory", "cannot be the root directory")}
 	}
@@ -208,6 +212,9 @@ func (p *fileDriver) Validate(values map[string]any) (string, []internal.FieldEr
 		if !ok {
 			return "", []internal.FieldError{internal.NewFieldError("Directory", fmt.Sprintf("%s directory isn't writable", absdir))}
 		}
+	}
+	if len(fieldErrors) > 0 {
+		return "", fieldErrors
 	}
 	return "file://" + filepath.ToSlash(absdir), nil
 }

--- a/internal/drivers/file/file_test.go
+++ b/internal/drivers/file/file_test.go
@@ -19,4 +19,10 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, errs)
 	assert.Equal(t, "file://"+tmpdir, url)
+
+	url, errs = driver.Validate(map[string]any{
+		"Format": "json", // missing required field Directory
+	})
+	assert.GreaterOrEqual(t, len(errs), 1)
+	assert.Equal(t, "", url)
 }

--- a/internal/drivers/file/file_test.go
+++ b/internal/drivers/file/file_test.go
@@ -8,21 +8,39 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	var driver fileDriver
-
 	tmpdir, err := os.MkdirTemp("", "test")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	url, errs := driver.Validate(map[string]any{
-		"Directory": tmpdir,
-	})
-	assert.Empty(t, errs)
-	assert.Equal(t, "file://"+tmpdir, url)
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "valid directory",
+			config:      map[string]any{"Directory": tmpdir},
+			expectedURL: "file://" + tmpdir,
+		},
+		{
+			name:        "missing required field Directory",
+			config:      map[string]any{"Format": "json"},
+			expectError: true,
+		},
+	}
 
-	url, errs = driver.Validate(map[string]any{
-		"Format": "json", // missing required field Directory
-	})
-	assert.GreaterOrEqual(t, len(errs), 1)
-	assert.Equal(t, "", url)
+	var driver fileDriver
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }

--- a/internal/drivers/kafka/kafka.go
+++ b/internal/drivers/kafka/kafka.go
@@ -256,9 +256,20 @@ func (p *kafkaDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *kafkaDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	hostname := internal.GetRequiredStringValue("Hostname", values)
+	fieldErrors := []internal.FieldError{}
+	hostname, fieldError := internal.GetRequiredStringValue("Hostname", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
 	port := internal.GetOptionalIntValue("Port", 9092, values)
-	topic := internal.GetRequiredStringValue("Topic", values)
+	topic, fieldError := internal.GetRequiredStringValue("Topic", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
+
+	if len(fieldErrors) > 0 {
+		return "", fieldErrors
+	}
 	return fmt.Sprintf("kafka://%s:%d/%s", hostname, port, topic), nil
 }
 

--- a/internal/drivers/kafka/kafka_test.go
+++ b/internal/drivers/kafka/kafka_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestValidate(t *testing.T) {
 	var driver kafkaDriver
+
 	url, err := driver.Validate(map[string]any{
 		"Hostname": "hostname",
 		"Topic":    "topic",
@@ -22,4 +23,10 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, err)
 	assert.Equal(t, "kafka://hostname:9999/topic", url)
+
+	url, err = driver.Validate(map[string]any{
+		"Hostname": "hostname", // missing required field Topic
+	})
+	assert.GreaterOrEqual(t, len(err), 1)
+	assert.Equal(t, "", url)
 }

--- a/internal/drivers/kafka/kafka_test.go
+++ b/internal/drivers/kafka/kafka_test.go
@@ -7,26 +7,40 @@ import (
 )
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "minimal config",
+			config:      map[string]any{"Hostname": "hostname", "Topic": "topic"},
+			expectedURL: "kafka://hostname:9092/topic",
+		},
+		{
+			name:        "with custom port",
+			config:      map[string]any{"Hostname": "hostname", "Topic": "topic", "Port": 9999},
+			expectedURL: "kafka://hostname:9999/topic",
+		},
+		{
+			name:        "missing required field Topic",
+			config:      map[string]any{"Hostname": "hostname"},
+			expectError: true,
+		},
+	}
+
 	var driver kafkaDriver
-
-	url, err := driver.Validate(map[string]any{
-		"Hostname": "hostname",
-		"Topic":    "topic",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "kafka://hostname:9092/topic", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Hostname": "hostname",
-		"Topic":    "topic",
-		"Port":     9999,
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "kafka://hostname:9999/topic", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Hostname": "hostname", // missing required field Topic
-	})
-	assert.GreaterOrEqual(t, len(err), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }

--- a/internal/drivers/mysql/mysql.go
+++ b/internal/drivers/mysql/mysql.go
@@ -275,7 +275,8 @@ func (p *mysqlDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *mysqlDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	return internal.URLFromDatabaseConfiguration("mysql", 3306, values), nil
+	url, fieldErrors := internal.URLFromDatabaseConfiguration("mysql", 3306, values)
+	return url, fieldErrors
 }
 
 // MigrateNewTable is called when a new table is detected with the appropriate information for the driver to perform the migration.

--- a/internal/drivers/mysql/sql_test.go
+++ b/internal/drivers/mysql/sql_test.go
@@ -122,6 +122,13 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, err)
 	assert.Equal(t, "mysql://user:pass@hostname:1234/db", url)
+
+	url, err = driver.Validate(map[string]any{
+		"Database": "db", // missing required field Hostname
+		"Port":     3306,
+	})
+	assert.GreaterOrEqual(t, len(err), 1)
+	assert.Equal(t, "", url)
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/mysql/sql_test.go
+++ b/internal/drivers/mysql/sql_test.go
@@ -88,47 +88,52 @@ func TestParseDSN(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "minimal config",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname"},
+			expectedURL: "mysql://hostname:3306/db",
+		},
+		{
+			name:        "with custom port",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Port": 1234},
+			expectedURL: "mysql://hostname:1234/db",
+		},
+		{
+			name:        "with username",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Port": 1234, "Username": "user"},
+			expectedURL: "mysql://user:@hostname:1234/db",
+		},
+		{
+			name:        "with username and password",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Port": 1234, "Username": "user", "Password": "pass"},
+			expectedURL: "mysql://user:pass@hostname:1234/db",
+		},
+		{
+			name:        "missing required field Hostname",
+			config:      map[string]any{"Database": "db", "Port": 3306},
+			expectError: true,
+		},
+	}
+
 	var driver mysqlDriver
-	url, err := driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "mysql://hostname:3306/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Port":     1234,
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "mysql://hostname:1234/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Port":     1234,
-		"Username": "user",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "mysql://user:@hostname:1234/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Port":     1234,
-		"Username": "user",
-		"Password": "pass",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "mysql://user:pass@hostname:1234/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db", // missing required field Hostname
-		"Port":     3306,
-	})
-	assert.GreaterOrEqual(t, len(err), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/postgresql/postgresql.go
+++ b/internal/drivers/postgresql/postgresql.go
@@ -16,6 +16,7 @@ import (
 
 const maxBytesSizeInsert = 5_000_000
 const maxBatchSize = 500
+
 type postgresqlDriver struct {
 	ctx          context.Context
 	logger       logger.Logger
@@ -278,7 +279,8 @@ func (p *postgresqlDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *postgresqlDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	return internal.URLFromDatabaseConfiguration("postgres", 5432, values), nil
+	url, fieldErrors := internal.URLFromDatabaseConfiguration("postgres", 5432, values)
+	return url, fieldErrors
 }
 
 // MigrateNewTable is called when a new table is detected with the appropriate information for the driver to perform the migration.

--- a/internal/drivers/postgresql/sql_test.go
+++ b/internal/drivers/postgresql/sql_test.go
@@ -119,6 +119,13 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, err)
 	assert.Equal(t, "postgres://user:pass@hostname:1234/db", url)
+
+	url, err = driver.Validate(map[string]any{
+		"Hostname": "hostname", // missing required field Database
+		"Port":     5432,
+	})
+	assert.GreaterOrEqual(t, len(err), 1)
+	assert.Equal(t, "", url)
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/postgresql/sql_test.go
+++ b/internal/drivers/postgresql/sql_test.go
@@ -85,47 +85,52 @@ func TestDBConnectionString(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "minimal config",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname"},
+			expectedURL: "postgres://hostname:5432/db",
+		},
+		{
+			name:        "with custom port",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Port": 1234},
+			expectedURL: "postgres://hostname:1234/db",
+		},
+		{
+			name:        "with username",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Port": 1234, "Username": "user"},
+			expectedURL: "postgres://user:@hostname:1234/db",
+		},
+		{
+			name:        "with username and password",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Port": 1234, "Username": "user", "Password": "pass"},
+			expectedURL: "postgres://user:pass@hostname:1234/db",
+		},
+		{
+			name:        "missing required field Database",
+			config:      map[string]any{"Hostname": "hostname", "Port": 5432},
+			expectError: true,
+		},
+	}
+
 	var driver postgresqlDriver
-	url, err := driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "postgres://hostname:5432/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Port":     1234,
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "postgres://hostname:1234/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Port":     1234,
-		"Username": "user",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "postgres://user:@hostname:1234/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Port":     1234,
-		"Username": "user",
-		"Password": "pass",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "postgres://user:pass@hostname:1234/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Hostname": "hostname", // missing required field Database
-		"Port":     5432,
-	})
-	assert.GreaterOrEqual(t, len(err), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/s3/s3.go
+++ b/internal/drivers/s3/s3.go
@@ -471,7 +471,11 @@ func (p *s3Driver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *s3Driver) Validate(values map[string]any) (string, []internal.FieldError) {
-	bucket := internal.GetRequiredStringValue("Bucket", values)
+	fieldErrors := []internal.FieldError{}
+	bucket, fieldError := internal.GetRequiredStringValue("Bucket", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
 	prefix := internal.GetOptionalStringValue("Prefix", "", values)
 	region := internal.GetOptionalStringValue("Region", "", values)
 	accesskey := internal.GetOptionalStringValue("Access Key ID", "", values)
@@ -503,6 +507,10 @@ func (p *s3Driver) Validate(values map[string]any) (string, []internal.FieldErro
 		q.Set("secret-access-key", secret)
 	}
 	url.RawQuery = q.Encode()
+
+	if len(fieldErrors) > 0 {
+		return "", fieldErrors
+	}
 	return url.String(), nil
 }
 

--- a/internal/drivers/s3/s3_test.go
+++ b/internal/drivers/s3/s3_test.go
@@ -147,6 +147,12 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, err)
 	assert.Equal(t, "s3://storage.googleapis.com/bucket/foo?access-key-id=AKIAIOSFODNN7EXAMPLE&region=us-east-1&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY", url)
+
+	url, err = driver.Validate(map[string]any{
+		"Region": "us-east-1", // missing required field Bucket
+	})
+	assert.GreaterOrEqual(t, len(err), 1)
+	assert.Equal(t, "", url)
 }
 
 func TestSchemaValidationPath(t *testing.T) {

--- a/internal/drivers/s3/s3_test.go
+++ b/internal/drivers/s3/s3_test.go
@@ -76,83 +76,77 @@ func TestGetBucketInfoGCP(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "minimal config",
+			config:      map[string]any{"Bucket": "bucket"},
+			expectedURL: "s3://bucket",
+		},
+		{
+			name:        "with prefix",
+			config:      map[string]any{"Bucket": "bucket", "Prefix": "prefix"},
+			expectedURL: "s3://bucket/prefix",
+		},
+		{
+			name:        "with leading slash prefix",
+			config:      map[string]any{"Bucket": "bucket", "Prefix": "/prefix"},
+			expectedURL: "s3://bucket/prefix",
+		},
+		{
+			name:        "with endpoint and prefix",
+			config:      map[string]any{"Bucket": "bucket", "Prefix": "/prefix", "Endpoint": "storage.googleapis.com"},
+			expectedURL: "s3://storage.googleapis.com/bucket/prefix",
+		},
+		{
+			name:        "with endpoint prefix no slash",
+			config:      map[string]any{"Bucket": "bucket", "Prefix": "prefix", "Endpoint": "storage.googleapis.com"},
+			expectedURL: "s3://storage.googleapis.com/bucket/prefix",
+		},
+		{
+			name:        "with endpoint only",
+			config:      map[string]any{"Bucket": "bucket", "Endpoint": "storage.googleapis.com"},
+			expectedURL: "s3://storage.googleapis.com/bucket",
+		},
+		{
+			name:        "with access keys",
+			config:      map[string]any{"Bucket": "bucket", "Access Key ID": "AKIAIOSFODNN7EXAMPLE", "Secret Access Key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+			expectedURL: "s3://bucket?access-key-id=AKIAIOSFODNN7EXAMPLE&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY",
+		},
+		{
+			name:        "with region and access keys",
+			config:      map[string]any{"Bucket": "bucket", "Region": "us-east-1", "Access Key ID": "AKIAIOSFODNN7EXAMPLE", "Secret Access Key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+			expectedURL: "s3://bucket?access-key-id=AKIAIOSFODNN7EXAMPLE&region=us-east-1&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY",
+		},
+		{
+			name:        "full config",
+			config:      map[string]any{"Bucket": "bucket", "Endpoint": "storage.googleapis.com", "Prefix": "/foo", "Region": "us-east-1", "Access Key ID": "AKIAIOSFODNN7EXAMPLE", "Secret Access Key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+			expectedURL: "s3://storage.googleapis.com/bucket/foo?access-key-id=AKIAIOSFODNN7EXAMPLE&region=us-east-1&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY",
+		},
+		{
+			name:        "missing required field Bucket",
+			config:      map[string]any{"Region": "us-east-1"},
+			expectError: true,
+		},
+	}
+
 	var driver s3Driver
-	url, err := driver.Validate(map[string]any{
-		"Bucket": "bucket",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://bucket", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket": "bucket",
-		"Prefix": "prefix",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://bucket/prefix", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket": "bucket",
-		"Prefix": "/prefix",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://bucket/prefix", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket":   "bucket",
-		"Prefix":   "/prefix",
-		"Endpoint": "storage.googleapis.com",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://storage.googleapis.com/bucket/prefix", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket":   "bucket",
-		"Prefix":   "prefix",
-		"Endpoint": "storage.googleapis.com",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://storage.googleapis.com/bucket/prefix", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket":   "bucket",
-		"Endpoint": "storage.googleapis.com",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://storage.googleapis.com/bucket", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket":            "bucket",
-		"Access Key ID":     "AKIAIOSFODNN7EXAMPLE",
-		"Secret Access Key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://bucket?access-key-id=AKIAIOSFODNN7EXAMPLE&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket":            "bucket",
-		"Region":            "us-east-1",
-		"Access Key ID":     "AKIAIOSFODNN7EXAMPLE",
-		"Secret Access Key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://bucket?access-key-id=AKIAIOSFODNN7EXAMPLE&region=us-east-1&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Bucket":            "bucket",
-		"Endpoint":          "storage.googleapis.com",
-		"Prefix":            "/foo",
-		"Region":            "us-east-1",
-		"Access Key ID":     "AKIAIOSFODNN7EXAMPLE",
-		"Secret Access Key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "s3://storage.googleapis.com/bucket/foo?access-key-id=AKIAIOSFODNN7EXAMPLE&region=us-east-1&secret-access-key=wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Region": "us-east-1", // missing required field Bucket
-	})
-	assert.GreaterOrEqual(t, len(err), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }
 
 func TestSchemaValidationPath(t *testing.T) {

--- a/internal/drivers/snowflake/snowflake.go
+++ b/internal/drivers/snowflake/snowflake.go
@@ -451,7 +451,8 @@ func (p *snowflakeDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *snowflakeDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	return internal.URLFromDatabaseConfiguration("snowflake", -1, values), nil
+	url, fieldErrors := internal.URLFromDatabaseConfiguration("snowflake", -1, values)
+	return url, fieldErrors
 }
 
 // MigrateNewTable is called when a new table is detected with the appropriate information for the driver to perform the migration.

--- a/internal/drivers/snowflake/snowflake_keypair.go
+++ b/internal/drivers/snowflake/snowflake_keypair.go
@@ -124,9 +124,19 @@ func (p *snowflakeKeyPairDriver) connectToDBWithKeyPair(ctx context.Context, url
 }
 
 func (p *snowflakeKeyPairDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	account := internal.GetRequiredStringValue("Account", values)
-	database := internal.GetRequiredStringValue("Database", values)
-	username := internal.GetRequiredStringValue("Username", values)
+	fieldErrors := []internal.FieldError{}
+	account, fieldError := internal.GetRequiredStringValue("Account", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
+	database, fieldError := internal.GetRequiredStringValue("Database", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
+	username, fieldError := internal.GetRequiredStringValue("Username", values)
+	if fieldError != nil {
+		fieldErrors = append(fieldErrors, *fieldError)
+	}
 	secret := internal.GetOptionalStringValue("Secret", "", values)
 
 	var u url.URL
@@ -137,6 +147,10 @@ func (p *snowflakeKeyPairDriver) Validate(values map[string]any) (string, []inte
 	q := u.Query()
 	q.Set(secretKey, secret)
 	u.RawQuery = q.Encode()
+
+	if len(fieldErrors) > 0 {
+		return "", fieldErrors
+	}
 	return u.String(), nil
 }
 

--- a/internal/drivers/snowflake/sql_test.go
+++ b/internal/drivers/snowflake/sql_test.go
@@ -59,37 +59,47 @@ func TestConnectionString(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "minimal config",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname"},
+			expectedURL: "snowflake://hostname/db",
+		},
+		{
+			name:        "with username",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Username": "user"},
+			expectedURL: "snowflake://user:@hostname/db",
+		},
+		{
+			name:        "with username and password",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname", "Username": "user", "Password": "pass"},
+			expectedURL: "snowflake://user:pass@hostname/db",
+		},
+		{
+			name:        "missing required field Database",
+			config:      map[string]any{"Hostname": "hostname", "Username": "user"},
+			expectError: true,
+		},
+	}
+
 	var driver snowflakeDriver
-	url, err := driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "snowflake://hostname/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Username": "user",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "snowflake://user:@hostname/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-		"Username": "user",
-		"Password": "pass",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "snowflake://user:pass@hostname/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Hostname": "hostname", // missing required field Database
-		"Username": "user",
-	})
-	assert.GreaterOrEqual(t, len(err), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/snowflake/sql_test.go
+++ b/internal/drivers/snowflake/sql_test.go
@@ -83,6 +83,13 @@ func TestValidate(t *testing.T) {
 	})
 	assert.Empty(t, err)
 	assert.Equal(t, "snowflake://user:pass@hostname/db", url)
+
+	url, err = driver.Validate(map[string]any{
+		"Hostname": "hostname", // missing required field Database
+		"Username": "user",
+	})
+	assert.GreaterOrEqual(t, len(err), 1)
+	assert.Equal(t, "", url)
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/sqlserver/sql_test.go
+++ b/internal/drivers/sqlserver/sql_test.go
@@ -111,21 +111,37 @@ func TestParseDSN(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]any
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "minimal config",
+			config:      map[string]any{"Database": "db", "Hostname": "hostname"},
+			expectedURL: "sqlserver://hostname:1433/db",
+		},
+		{
+			name:        "missing required field Hostname",
+			config:      map[string]any{"Database": "db", "Port": 1433},
+			expectError: true,
+		},
+	}
+
 	var driver sqlserverDriver
-
-	url, err := driver.Validate(map[string]any{
-		"Database": "db",
-		"Hostname": "hostname",
-	})
-	assert.Empty(t, err)
-	assert.Equal(t, "sqlserver://hostname:1433/db", url)
-
-	url, err = driver.Validate(map[string]any{
-		"Database": "db", // missing required field Hostname
-		"Port":     1433,
-	})
-	assert.GreaterOrEqual(t, len(err), 1)
-	assert.Equal(t, "", url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, errs := driver.Validate(tt.config)
+			if tt.expectError {
+				assert.GreaterOrEqual(t, len(errs), 1)
+				assert.Equal(t, "", url)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.expectedURL, url)
+			}
+		})
+	}
 }
 
 func TestAddNewColumnsSQL(t *testing.T) {

--- a/internal/drivers/sqlserver/sql_test.go
+++ b/internal/drivers/sqlserver/sql_test.go
@@ -110,6 +110,24 @@ func TestParseDSN(t *testing.T) {
 	assert.Equal(t, "sqlserver://root:password@foo.microsoft.com:3306?app+name=eds&database=eds", dsn)
 }
 
+func TestValidate(t *testing.T) {
+	var driver sqlserverDriver
+
+	url, err := driver.Validate(map[string]any{
+		"Database": "db",
+		"Hostname": "hostname",
+	})
+	assert.Empty(t, err)
+	assert.Equal(t, "sqlserver://hostname:1433/db", url)
+
+	url, err = driver.Validate(map[string]any{
+		"Database": "db", // missing required field Hostname
+		"Port":     1433,
+	})
+	assert.GreaterOrEqual(t, len(err), 1)
+	assert.Equal(t, "", url)
+}
+
 func TestAddNewColumnsSQL(t *testing.T) {
 	logger := logger.NewConsoleLogger()
 	detail := getOrderSchema()

--- a/internal/drivers/sqlserver/sqlserver.go
+++ b/internal/drivers/sqlserver/sqlserver.go
@@ -279,7 +279,8 @@ func (p *sqlserverDriver) Configuration() []internal.DriverField {
 
 // Validate validates the configuration and returns an error if the configuration is invalid or a valid url if the configuration is valid.
 func (p *sqlserverDriver) Validate(values map[string]any) (string, []internal.FieldError) {
-	return internal.URLFromDatabaseConfiguration("sqlserver", 1433, values), nil
+	url, fieldErrors := internal.URLFromDatabaseConfiguration("sqlserver", 1433, values)
+	return url, fieldErrors
 }
 
 // MigrateNewTable is called when a new table is detected with the appropriate information for the driver to perform the migration.

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -1,0 +1,117 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	natsserver "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+	"github.com/shopmonkeyus/eds/internal"
+	"github.com/shopmonkeyus/eds/internal/util"
+	"github.com/stretchr/testify/assert"
+
+	_ "github.com/shopmonkeyus/eds/internal/drivers/eventhub"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/file"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/kafka"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/mysql"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/postgresql"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/s3"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/snowflake"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/sqlserver"
+)
+
+func runNatsTestServer(fn func(natsurl string, nc *nats.Conn, srv *server.Server)) {
+	port, err := util.GetFreePort()
+	if err != nil {
+		panic(err)
+	}
+	opts := natsserver.DefaultTestOptions
+	opts.Port = port
+	opts.Cluster.Name = "testing"
+	srv := natsserver.RunServer(&opts)
+	defer srv.Shutdown()
+	url := fmt.Sprintf("nats://localhost:%d", port)
+	nc, err := nats.Connect(url)
+	if err != nil {
+		panic(err)
+	}
+	defer nc.Close()
+	fn(url, nc, srv)
+}
+
+func TestAllDriversReturnFieldErrorsOnEmptyConfig(t *testing.T) {
+	runNatsTestServer(func(natsurl string, nc *nats.Conn, srv *server.Server) {
+		sessionID := "test-session-all-drivers"
+
+		handler := NotificationHandler{
+			Validate: func(driver string, values map[string]any) *ValidateResponse {
+				url, fieldErrs, err := internal.Validate(driver, values)
+				var msg string
+				if err != nil {
+					msg = err.Error()
+				}
+				return &ValidateResponse{
+					Success:     err == nil && url != "",
+					SessionID:   sessionID,
+					FieldErrors: fieldErrs,
+					URL:         url,
+					Message:     msg,
+				}
+			},
+		}
+
+		subject := fmt.Sprintf("eds.notify.%s.validate", sessionID)
+		sub, err := nc.Subscribe(subject, func(m *nats.Msg) {
+			var notification Notification
+			if err := util.DecodeNatsMsg(m, &notification); err != nil {
+				t.Errorf("failed to decode notification: %s", err)
+				return
+			}
+
+			var driver string
+			var config map[string]any
+			if v, ok := notification.Data["driver"].(string); ok {
+				driver = v
+			}
+			if v, ok := notification.Data["config"].(map[string]any); ok {
+				config = v
+			}
+
+			response := handler.Validate(driver, config)
+			respData, _ := json.Marshal(response)
+			m.Respond(respData)
+		})
+		assert.NoError(t, err)
+		defer sub.Unsubscribe()
+
+		// Get all registered drivers and test each one
+		drivers := internal.GetDriverConfigurations()
+
+		for driverName := range drivers {
+			t.Run(driverName+"_empty_config", func(t *testing.T) {
+				notification := Notification{
+					Action: "validate",
+					Data: map[string]any{
+						"driver": driverName,
+						"config": map[string]any{},
+					},
+				}
+
+				resp, err := nc.Request(subject, []byte(util.JSONStringify(notification)), 5*time.Second)
+				assert.NoError(t, err)
+
+				var validateResp ValidateResponse
+				err = json.Unmarshal(resp.Data, &validateResp)
+				assert.NoError(t, err)
+
+				assert.False(t, validateResp.Success, "%s: validation should fail with empty config", driverName)
+				assert.GreaterOrEqual(t, len(validateResp.FieldErrors), 1, "%s: should return at least one field error", driverName)
+				assert.Equal(t, "", validateResp.URL, "%s: URL should be empty on validation failure", driverName)
+			})
+		}
+	})
+}
+

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shopmonkeyus/eds/internal/util"
 	"github.com/stretchr/testify/assert"
 
-	_ "github.com/shopmonkeyus/eds/internal/drivers/eventhub"
+	_ "github.com/shopmonkeyus/eds/internal/drivers/eventhub" // this comment on this blank import is needed because Sonarqube doesn't understand Go modules
 	_ "github.com/shopmonkeyus/eds/internal/drivers/file"
 	_ "github.com/shopmonkeyus/eds/internal/drivers/kafka"
 	_ "github.com/shopmonkeyus/eds/internal/drivers/mysql"
@@ -114,4 +114,3 @@ func TestAllDriversReturnFieldErrorsOnEmptyConfig(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION
If the user clicked the next button with an empty required field while configuring an EDS server in HQ, it would just spin for a minute and then show a generic error toast. The EDS server was just panicking in the background and restarting. You could technically proceed after you waited for a minute but the UX was pretty bad here.

We already had a mechanism for returning errors on specific fields, e.g. wrong password, so it was pretty simple to just wire the error up to the response and have it show in the frontend.
