### PR TITLE
[PIT-2053] NATS urls per environment

### DIFF
--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -60,6 +60,12 @@ var enrollCmd = &cobra.Command{
 			logger.Fatal("failed to start enroll: %s", enrollResp.Message)
 		}
 
+		natsURL, err := api.GetNatsURL(code[0:1])
+		if err != nil {
+			logger.Fatal("error getting nats url: %s", err)
+		}
+		enrollResp.Data.NatsURL = natsURL
+
 		var buf bytes.Buffer
 		if err := toml.NewEncoder(&buf).Encode(enrollResp.Data); err != nil {
 			logger.Fatal("failed to encode response: %w", err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -479,7 +479,6 @@ var serverCmd = &cobra.Command{
 		}
 		dataDir := getDataDir(cmd, logger)
 		driverURL := viper.GetString("url")
-		server := mustFlagString(cmd, "server", false)
 		apikey := viper.GetString("token")
 		if apikey == "" {
 			logger.Fatal("API key not found. Make sure you run %s before continuing.", getCommandExample("enroll", "[CODE]"))
@@ -515,6 +514,14 @@ var serverCmd = &cobra.Command{
 			logger.Debug("using API url: %s", apiurl)
 		}
 
+		natsurl := api.GetNatsURLFromAPIURL(apiurl)
+		if cmd.Flags().Changed("server") {
+			natsurl = mustFlagString(cmd, "server", true)
+			logger.Debug("using alternative NATS url: %s", natsurl)
+		} else {
+			logger.Debug("using NATS url: %s", natsurl)
+		}
+
 		var credsFile string
 		var sessionDir string
 
@@ -538,7 +545,7 @@ var serverCmd = &cobra.Command{
 		_args := collectCommandArgs()
 		_args = append(_args, "--port", fmt.Sprintf("%d", port))
 		_args = append(_args, "--data-dir", dataDir)
-		_args = append(_args, "--server", server)
+		_args = append(_args, "--server", natsurl)
 		_args = append(_args, "--api-url", apiurl)
 
 		var sessionId string
@@ -918,11 +925,6 @@ var serverCmd = &cobra.Command{
 				URL:         url,
 				Message:     msg,
 			}
-		}
-
-		natsurl := mustFlagString(cmd, "server", true)
-		if strings.Contains(apiurl, "localhost") {
-			natsurl = "nats://localhost:4222"
 		}
 
 		// create a notification consumer that will listen for notification actions and handle them here

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -514,10 +514,12 @@ var serverCmd = &cobra.Command{
 			logger.Debug("using API url: %s", apiurl)
 		}
 
-		natsurl := api.GetNatsURLFromAPIURL(apiurl)
+		natsurl := mustFlagString(cmd, "server", true)
 		if cmd.Flags().Changed("server") {
-			natsurl = mustFlagString(cmd, "server", true)
 			logger.Debug("using alternative NATS url: %s", natsurl)
+		} else if configNats := viper.GetString("nats_url"); configNats != "" {
+			natsurl = configNats
+			logger.Debug("using NATS url from config: %s", natsurl)
 		} else {
 			logger.Debug("using NATS url: %s", natsurl)
 		}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -52,6 +52,7 @@ type SessionEndResponse struct {
 type EnrollTokenData struct {
 	Token    string `json:"token" toml:"token"`
 	ServerID string `json:"serverId" toml:"server_id"`
+	NatsURL  string `json:"natsUrl,omitempty" toml:"nats_url,omitempty"`
 }
 
 type EnrollResponse struct {
@@ -62,31 +63,43 @@ type EnrollResponse struct {
 
 const defaultNatsURL = "nats://connect.nats.shopmonkey.pub"
 
-var apiToNatsURLs = map[string]string{
-	"https://api.shopmonkey.cloud":      defaultNatsURL,
-	"https://edge-api.shopmonkey.cloud": "nats://connect.nats-test.shopmonkey.pub",
-	"http://localhost:3101":             "nats://localhost:4222",
+type environment struct {
+	API  string
+	NATS string
+}
+
+var environments = map[string]environment{
+	"P": {API: "https://api.shopmonkey.cloud", NATS: defaultNatsURL},
+	"S": {API: "https://sandbox-api.shopmonkey.cloud", NATS: "nats://connect.nats-sandbox.shopmonkey.pub"},
+	"E": {API: "https://edge-api.shopmonkey.cloud", NATS: "nats://connect.nats-test.shopmonkey.pub"},
+	"L": {API: "http://localhost:3101", NATS: "nats://localhost:4222"},
 }
 
 func GetAPIURL(firstLetter string) (*string, error) {
-	apiUrls := map[string]string{
-		"P": "https://api.shopmonkey.cloud",
-		"S": "https://sandbox-api.shopmonkey.cloud",
-		"E": "https://edge-api.shopmonkey.cloud",
-		"L": "http://localhost:3101",
+	env, err := getEnvironment(firstLetter)
+	if err != nil {
+		return nil, err
 	}
-
-	if url, exists := apiUrls[firstLetter]; exists {
-		return &url, nil
-	}
-	return nil, errors.New("invalid code")
+	return &env.API, nil
 }
 
-// GetNatsURLFromAPIURL returns the NATS server URL for a Shopmonkey API URL.
-func GetNatsURLFromAPIURL(apiURL string) string {
-	apiURL = strings.TrimSuffix(apiURL, "/")
-	if natsURL, ok := apiToNatsURLs[apiURL]; ok {
-		return natsURL
+func GetNatsURL(firstLetter string) (string, error) {
+	env, err := getEnvironment(firstLetter)
+	if err != nil {
+		return "", err
 	}
-	return defaultNatsURL
+	return env.NATS, nil
+}
+
+func getEnvironment(code string) (environment, error) {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	if code == "" {
+		return environment{}, errors.New("invalid code")
+	}
+	code = code[0:1]
+	env, exists := environments[code]
+	if !exists {
+		return environment{}, errors.New("invalid code")
+	}
+	return env, nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,6 +1,9 @@
 package api
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 type DriverMeta struct {
 	ID          string `json:"id"`
@@ -57,6 +60,14 @@ type EnrollResponse struct {
 	Data    EnrollTokenData `json:"data"`
 }
 
+const defaultNatsURL = "nats://connect.nats.shopmonkey.pub"
+
+var apiToNatsURLs = map[string]string{
+	"https://api.shopmonkey.cloud":      defaultNatsURL,
+	"https://edge-api.shopmonkey.cloud": "nats://connect.nats-test.shopmonkey.pub",
+	"http://localhost:3101":             "nats://localhost:4222",
+}
+
 func GetAPIURL(firstLetter string) (*string, error) {
 	apiUrls := map[string]string{
 		"P": "https://api.shopmonkey.cloud",
@@ -69,4 +80,13 @@ func GetAPIURL(firstLetter string) (*string, error) {
 		return &url, nil
 	}
 	return nil, errors.New("invalid code")
+}
+
+// GetNatsURLFromAPIURL returns the NATS server URL for a Shopmonkey API URL.
+func GetNatsURLFromAPIURL(apiURL string) string {
+	apiURL = strings.TrimSuffix(apiURL, "/")
+	if natsURL, ok := apiToNatsURLs[apiURL]; ok {
+		return natsURL
+	}
+	return defaultNatsURL
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,24 +1,37 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGetNatsURLFromAPIURL(t *testing.T) {
-	tests := []struct {
-		apiURL  string
-		natsURL string
-	}{
-		{"https://api.shopmonkey.cloud", defaultNatsURL},
-		{"https://api.shopmonkey.cloud/", defaultNatsURL},
-		{"https://edge-api.shopmonkey.cloud", "nats://connect.nats-test.shopmonkey.pub"},
-		{"http://localhost:3101", "nats://localhost:4222"},
-		{"https://sandbox-api.shopmonkey.cloud", defaultNatsURL},
-		{"https://unknown.example.com", defaultNatsURL},
+func TestGetAPIURL(t *testing.T) {
+	url, err := GetAPIURL("P")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.shopmonkey.cloud", *url)
+
+	url, err = GetAPIURL("e")
+	require.NoError(t, err)
+	assert.Equal(t, "https://edge-api.shopmonkey.cloud", *url)
+
+	_, err = GetAPIURL("X")
+	assert.Error(t, err)
+}
+
+func TestGetNatsURL(t *testing.T) {
+	for code, env := range environments {
+		natsURL, err := GetNatsURL(code)
+		require.NoError(t, err)
+		assert.Equal(t, env.NATS, natsURL, code)
+
+		natsURL, err = GetNatsURL(strings.ToLower(code))
+		require.NoError(t, err)
+		assert.Equal(t, env.NATS, natsURL, code)
 	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.natsURL, GetNatsURLFromAPIURL(tt.apiURL), tt.apiURL)
-	}
+
+	_, err := GetNatsURL("X")
+	assert.Error(t, err)
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNatsURLFromAPIURL(t *testing.T) {
+	tests := []struct {
+		apiURL  string
+		natsURL string
+	}{
+		{"https://api.shopmonkey.cloud", defaultNatsURL},
+		{"https://api.shopmonkey.cloud/", defaultNatsURL},
+		{"https://edge-api.shopmonkey.cloud", "nats://connect.nats-test.shopmonkey.pub"},
+		{"http://localhost:3101", "nats://localhost:4222"},
+		{"https://sandbox-api.shopmonkey.cloud", defaultNatsURL},
+		{"https://unknown.example.com", defaultNatsURL},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.natsURL, GetNatsURLFromAPIURL(tt.apiURL), tt.apiURL)
+	}
+}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -226,7 +226,7 @@ func RunTests(logger logger.Logger, only []string) (bool, error) {
 		logger.Trace("creds: %s", userCreds)
 		httpport, shutdown := setupServer(logger, userCreds)
 		apiurl := fmt.Sprintf("http://127.0.0.1:%d", httpport)
-		run("enroll", []string{"--api-url", apiurl, "-v", "-d", tmpdir, "1234"}, nil, nil)
+		run("enroll", []string{"--api-url", apiurl, "-v", "-d", tmpdir, "L1234"}, nil, nil)
 		for _, test := range tests {
 			if tv, ok := test.(e2eTestDisabled); ok {
 				if tv.Disabled() {


### PR DESCRIPTION
EDS no longer works in our test environments because the NATS url has changed for Edge and Sandbox. This PR adds per-environment NATS urls so users don't have to specify with flags. The NATS url is derived from the enrollment code similarly to the API url, and it is saved to the config file. The command line flag takes precedence over the config file, and if neither are present it uses the existing default, which is the prod url so this will not affect existing production installs of EDS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/shopmonkeyus/codesmith/eds/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786301458&installation_id=59919248&pr_number=549&repository=shopmonkeyus%2Feds&return_to=https%3A%2F%2Fgithub.com%2Fshopmonkeyus%2Feds%2Fpull%2F549&signature=21ac5bf6ef5ee3da3f4f265816d9f28cbcaaecb4869a539bf5d0f226283e1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->